### PR TITLE
Add delta-bkg tracking, and improved SED handling.

### DIFF
--- a/fgcm/fgcmApplyZeropoints.py
+++ b/fgcm/fgcmApplyZeropoints.py
@@ -145,6 +145,9 @@ class FgcmApplyZeropoints(object):
         if (not self.setupComplete):
             raise RuntimeError("Must complete applyZeropoints setup first!")
 
+        if self.fgcmStars.hasDeltaMagBkg:
+            self.fgcmStars.applyDeltaMagBkg()
+
         # Select good exposures based on the flag cuts
         # Can do this only for exposures that are ALL above the threshold.
 
@@ -168,10 +171,13 @@ class FgcmApplyZeropoints(object):
         goodExpsIndex, = np.where(self.fgcmPars.expFlag == 0)
         self.fgcmStars.selectStarsMinObsExpIndex(goodExpsIndex)
 
-        # Compute m^std and <m^std> using the zeropoints, no chromatic
-        #  corrections, no error modeling.
+        # Compute m^std and <m^std> using the zeropoints, compute SEDs,
+        # no error modeling.
 
         self.fgcmZpsToApply.applyZeropoints()
+
+        # Compute median SED slopes and apply
+        self.fgcmStars.fillMissingSedSlopes(self.fgcmPars)
 
         # Apply any color cuts
         self.fgcmStars.performColorCuts()

--- a/fgcm/fgcmChisq.py
+++ b/fgcm/fgcmChisq.py
@@ -521,6 +521,7 @@ class FgcmChisq(object):
         obsMagADU = snmm.getArray(self.fgcmStars.obsMagADUHandle)
         obsMagADUModelErr = snmm.getArray(self.fgcmStars.obsMagADUModelErrHandle)
         obsMagStd = snmm.getArray(self.fgcmStars.obsMagStdHandle)
+        obsDeltaStd = snmm.getArray(self.fgcmStars.obsDeltaStdHandle)
 
         # and fgcmGray stuff (if desired)
         if (self.fgcmGray is not None):
@@ -662,6 +663,8 @@ class FgcmChisq(object):
         obsMagStdLock.acquire()
 
         obsMagStd[goodObs] = obsMagGO + deltaStdGO
+        obsDeltaStd[goodObs] = deltaStdGO
+
         # this is cut here
         obsMagStdGO = obsMagStd[goodObs]
 

--- a/fgcm/fgcmConfig.py
+++ b/fgcm/fgcmConfig.py
@@ -140,6 +140,8 @@ class FgcmConfig(object):
     cycleNumber = ConfigField(int, default=0)
     outfileBase = ConfigField(str, required=True)
     maxIter = ConfigField(int, default=50)
+    deltaMagBkgOffsetPercentile = ConfigField(float, default=0.25)
+    deltaMagBkgPerCcd = ConfigField(bool, default=True)
     sigFgcmMaxErr = ConfigField(float, default=0.01)
     sigFgcmMaxEGrayDict = ConfigField(dict, default={})
     ccdGrayMaxStarErr = ConfigField(float, default=0.10)

--- a/fgcm/fgcmGray.py
+++ b/fgcm/fgcmGray.py
@@ -70,6 +70,7 @@ class FgcmGray(object):
         self.plotPath = fgcmConfig.plotPath
         self.outfileBaseWithCycle = fgcmConfig.outfileBaseWithCycle
         self.cycleNumber = fgcmConfig.cycleNumber
+        self.deltaMagBkgOffsetPercentile = fgcmConfig.deltaMagBkgOffsetPercentile
         self.expGrayCheckDeltaT = fgcmConfig.expGrayCheckDeltaT
         self.colorSplitIndices = fgcmConfig.colorSplitIndices
         self.bandFitIndex = fgcmConfig.bandFitIndex
@@ -101,6 +102,7 @@ class FgcmGray(object):
         # and the exp/ccd gray for the zeropoints
 
         self.ccdGrayHandle = snmm.createArray((self.fgcmPars.nExp,self.fgcmPars.nCCD),dtype='f8')
+        self.ccdDeltaStdHandle = snmm.createArray((self.fgcmPars.nExp, self.fgcmPars.nCCD), dtype='f8')
         self.ccdGrayRMSHandle = snmm.createArray((self.fgcmPars.nExp,self.fgcmPars.nCCD),dtype='f8')
         self.ccdGrayErrHandle = snmm.createArray((self.fgcmPars.nExp,self.fgcmPars.nCCD),dtype='f8')
         self.ccdNGoodObsHandle = snmm.createArray((self.fgcmPars.nExp,self.fgcmPars.nCCD),dtype='i4')
@@ -113,6 +115,7 @@ class FgcmGray(object):
             self.ccdGrayNPar = (order + 1) * (order + 1)
 
         self.expGrayHandle = snmm.createArray(self.fgcmPars.nExp,dtype='f8')
+        self.expDeltaStdHandle = snmm.createArray(self.fgcmPars.nExp, dtype='f8')
         self.expGrayRMSHandle = snmm.createArray(self.fgcmPars.nExp,dtype='f8')
         self.expGrayErrHandle = snmm.createArray(self.fgcmPars.nExp,dtype='f8')
         self.expNGoodStarsHandle = snmm.createArray(self.fgcmPars.nExp,dtype='i4')
@@ -123,6 +126,9 @@ class FgcmGray(object):
         self.expGrayRMSColorSplitHandle = snmm.createArray((self.fgcmPars.nExp, 3), dtype='f8')
         self.expGrayErrColorSplitHandle = snmm.createArray((self.fgcmPars.nExp, 3), dtype='f8')
         self.expGrayNGoodStarsColorSplitHandle = snmm.createArray((self.fgcmPars.nExp, 3), dtype='i2')
+
+        self.ccdDeltaMagBkgHandle = snmm.createArray((self.fgcmPars.nExp, self.fgcmPars.nCCD), dtype='f8')
+        self.expDeltaMagBkgHandle = snmm.createArray(self.fgcmPars.nExp, dtype='f8')
 
         self.arraysPrepared = True
 
@@ -266,6 +272,7 @@ class FgcmGray(object):
 
         # values to set
         ccdGray = snmm.getArray(self.ccdGrayHandle)
+        ccdDeltaStd = snmm.getArray(self.ccdDeltaStdHandle)
         ccdGrayRMS = snmm.getArray(self.ccdGrayRMSHandle)
         ccdGrayErr = snmm.getArray(self.ccdGrayErrHandle)
         ccdNGoodObs = snmm.getArray(self.ccdNGoodObsHandle)
@@ -276,6 +283,7 @@ class FgcmGray(object):
             ccdGraySubCCDPars = snmm.getArray(self.ccdGraySubCCDParsHandle)
 
         expGray = snmm.getArray(self.expGrayHandle)
+        expDeltaStd = snmm.getArray(self.expDeltaStdHandle)
         expGrayRMS = snmm.getArray(self.expGrayRMSHandle)
         expGrayErr = snmm.getArray(self.expGrayErrHandle)
         expNGoodCCDs = snmm.getArray(self.expNGoodCCDsHandle)
@@ -288,6 +296,7 @@ class FgcmGray(object):
         objNGoodObs = snmm.getArray(self.fgcmStars.objNGoodObsHandle)
 
         obsMagStd = snmm.getArray(self.fgcmStars.obsMagStdHandle)
+        obsDeltaStd = snmm.getArray(self.fgcmStars.obsDeltaStdHandle)
         obsMagErr = snmm.getArray(self.fgcmStars.obsMagADUModelErrHandle)
         obsBandIndex = snmm.getArray(self.fgcmStars.obsBandIndexHandle)
         obsCCDIndex = snmm.getArray(self.fgcmStars.obsCCDHandle) - self.ccdStartIndex
@@ -314,6 +323,8 @@ class FgcmGray(object):
         EGrayGO=EGrayGO[gd]
         EGrayErr2GO=EGrayErr2GO[gd]
 
+        obsDeltaStdGO = obsDeltaStd[goodObs]
+
         if np.any(self.ccdGraySubCCD):
             obsXGO = snmm.getArray(self.fgcmStars.obsXHandle)[goodObs]
             obsYGO = snmm.getArray(self.fgcmStars.obsYHandle)[goodObs]
@@ -328,6 +339,7 @@ class FgcmGray(object):
         ## ccdGrayErr = Sqrt(1./Sum(1./EGrayErr^2))
 
         ccdGray[:,:] = 0.0
+        ccdDeltaStd[:, :] = 0.0
         ccdGrayRMS[:,:] = 0.0
         ccdGrayErr[:,:] = 0.0
         ccdNGoodObs[:,:] = 0
@@ -348,6 +360,12 @@ class FgcmGray(object):
                   (obsExpIndex[goodObs],obsCCDIndex[goodObs]),
                   objNGoodObs[obsObjIDIndex[goodObs],
                               obsBandIndex[goodObs]])
+        np.add.at(ccdDeltaStd,
+                  (obsExpIndex[goodObs], obsCCDIndex[goodObs]),
+                  obsDeltaStdGO/EGrayErr2GO)
+
+        gd = np.where((ccdNGoodStars >= 3) & (ccdGrayWt > 0.0))
+        ccdDeltaStd[gd] /= ccdGrayWt[gd]
 
         if not np.any(self.ccdGraySubCCD):
             np.add.at(ccdGray,
@@ -456,6 +474,7 @@ class FgcmGray(object):
         # set illegalValue for totally bad CCDs
         bad = np.where((ccdNGoodStars <= 2) | (ccdGrayWt <= 0.0))
         ccdGray[bad] = self.illegalValue
+        ccdDeltaStd[bad] = self.illegalValue
         ccdGrayRMS[bad] = self.illegalValue
         ccdGrayErr[bad] = self.illegalValue
 
@@ -482,6 +501,7 @@ class FgcmGray(object):
         # note: goodCCD[0] refers to the expIndex, goodCCD[1] to the CCDIndex
 
         expGray[:] = 0.0
+        expDeltaStd[:] = 0.0
         expGrayRMS[:] = 0.0
         expGrayErr[:] = 0.0
         expNGoodStars[:] = 0
@@ -509,10 +529,14 @@ class FgcmGray(object):
         np.add.at(expNGoodStars,
                   goodCCD[0],
                   ccdNGoodStars[goodCCD])
+        np.add.at(expDeltaStd,
+                  goodCCD[0],
+                  ccdDeltaStd[goodCCD]/ccdGrayErr[goodCCD]**2.)
 
         # need at least 3 or else computation can blow up
         gd, = np.where(expNGoodCCDs >= 3)
         expGray[gd] /= expGrayWt[gd]
+        expDeltaStd[gd] /= expGrayWt[gd]
         expGrayRMS[gd] = np.sqrt((expGrayRMS[gd]/expGrayWt[gd]) - (expGray[gd]**2.))
         expGrayErr[gd] = np.sqrt(1./expGrayWt[gd])
         expNGoodTilings[gd] /= expNGoodCCDs[gd]
@@ -520,10 +544,10 @@ class FgcmGray(object):
         # set illegal value for non-measurements
         bad, = np.where(expNGoodCCDs <= 2)
         expGray[bad] = self.illegalValue
+        expDeltaStd[bad] = self.illegalValue
         expGrayRMS[bad] = self.illegalValue
         expGrayErr[bad] = self.illegalValue
         expNGoodTilings[bad] = self.illegalValue
-
 
         self.fgcmPars.compExpGray[:] = expGray
         self.fgcmPars.compVarGray[gd] = expGrayRMS[gd]**2.
@@ -946,19 +970,86 @@ class FgcmGray(object):
         expGrayHighCut[:] = [float(f) for f in self.expGrayHighCut]
 
         for i in range(self.fgcmPars.nBands):
-            delta = np.clip(self.autoPhotometricCutNSig * self.fgcmPars.compReservedRawCrunchedRepeatability[i], 0.001, 1e5)
+            delta = np.clip(self.autoPhotometricCutNSig * self.fgcmPars.compReservedRawRepeatability[i], 0.001, 1e5)
 
             cut = -1 * int(np.ceil(delta / self.autoPhotometricCutStep)) * self.autoPhotometricCutStep
             # Clip the cut to a range from 2 times the input to 5 mmag
             expGrayPhotometricCut[i] = max(expGrayPhotometricCut[i]*2,
                                            min(cut, -0.005))
 
-            delta = np.clip(self.autoHighCutNSig * self.fgcmPars.compReservedRawCrunchedRepeatability[i], 0.001, 1e5)
+            delta = np.clip(self.autoHighCutNSig * self.fgcmPars.compReservedRawRepeatability[i], 0.001, 1e5)
             cut = int(np.ceil(delta / self.autoPhotometricCutStep)) * self.autoPhotometricCutStep
             expGrayHighCut[i] = max(0.005,
                                     min(cut, expGrayHighCut[i]*2))
 
         return (expGrayPhotometricCut, expGrayHighCut)
+
+    def computeCCDAndExpDeltaMagBkg(self):
+        """
+        Compute CCD and exposure delta-bkg offsets.
+        """
+        if not self.fgcmStars.hasDeltaMagBkg:
+            # There is nothing to compute.  Leave as 0s.
+            return
+
+        startTime = time.time()
+        self.fgcmLog.debug('Computing ccdDeltaMagBkg and ExpDeltaMagBkg.')
+
+        ccdDeltaMagBkg = snmm.getArray(self.ccdDeltaMagBkgHandle)
+        expDeltaMagBkg = snmm.getArray(self.expDeltaMagBkgHandle)
+
+        obsDeltaMagBkg = snmm.getArray(self.fgcmStars.obsDeltaMagBkgHandle)
+        obsMagADU = snmm.getArray(self.fgcmStars.obsMagADUHandle)
+        obsExpIndex = snmm.getArray(self.fgcmStars.obsExpIndexHandle)
+        obsCCDIndex = snmm.getArray(self.fgcmStars.obsCCDHandle) - self.ccdStartIndex
+        obsFlag = snmm.getArray(self.fgcmStars.obsFlagHandle)
+
+        goodObs, = np.where(obsFlag == 0)
+
+        # Do the exposures first
+        h, rev = esutil.stat.histogram(obsExpIndex[goodObs], rev=True)
+
+        expDeltaMagBkg[:] = self.illegalValue
+
+        use, = np.where(h > int(3./self.deltaMagBkgOffsetPercentile))
+        for i in use:
+            i1a = rev[rev[i]: rev[i + 1]]
+
+            eInd = obsExpIndex[goodObs[i1a[0]]]
+
+            mag = obsMagADU[goodObs[i1a]]
+
+            st = np.argsort(mag)
+            bright, = np.where(mag < mag[st[int(self.deltaMagBkgOffsetPercentile*st.size)]])
+            expDeltaMagBkg[eInd] = np.median(obsDeltaMagBkg[goodObs[i1a[bright]]])
+
+        # Set the per-ccd defaults to the exposure numbers
+        ccdDeltaMagBkg[:, :] = np.repeat(expDeltaMagBkg, self.fgcmPars.nCCD).reshape(ccdDeltaMagBkg.shape)
+
+        # Do the exp/ccd second
+        expCcdHash = obsExpIndex[goodObs]*(self.fgcmPars.nCCD + 1) + obsCCDIndex[goodObs]
+
+        h, rev = esutil.stat.histogram(expCcdHash, rev=True)
+
+        # We need at least 3 for a median, and of those from the percentile...
+        use, = np.where(h > int(3./self.deltaMagBkgOffsetPercentile))
+        for i in use:
+            i1a = rev[rev[i]: rev[i + 1]]
+
+            eInd = obsExpIndex[goodObs[i1a[0]]]
+            cInd = obsCCDIndex[goodObs[i1a[0]]]
+
+            mag = obsMagADU[goodObs[i1a]]
+
+            st = np.argsort(mag)
+            bright, = np.where(mag < mag[st[int(self.deltaMagBkgOffsetPercentile*st.size)]])
+            ccdDeltaMagBkg[eInd, cInd] = np.median(obsDeltaMagBkg[goodObs[i1a[bright]]])
+
+        self.fgcmPars.compExpDeltaMagBkg[:] = expDeltaMagBkg
+
+        if not self.quietMode:
+            self.fgcmLog.info('Computed ccdDeltaBkg and expDeltaBkg in %.2f seconds.' %
+                              (time.time() - startTime))
 
     def __getstate__(self):
         # Don't try to pickle the logger.

--- a/fgcm/fgcmParameters.py
+++ b/fgcm/fgcmParameters.py
@@ -325,6 +325,9 @@ class FgcmParameters(object):
         # Add in the mirror coating...
         self.compMirrorChromaticity = np.zeros((self.nLUTFilter, self.nCoatingIntervals + 1))
 
+        # And median SED slopes
+        self.compMedianSedSlope = np.zeros(self.nBands, dtype=np.float64)
+
         ## FIXME: need to completely refactor
         self.externalPwvFlag = np.zeros(self.nExp,dtype=np.bool)
         if (self.pwvFile is not None):
@@ -371,6 +374,8 @@ class FgcmParameters(object):
         self.compExpGray = np.zeros(self.nExp,dtype='f8')
         self.compVarGray = np.zeros(self.nExp,dtype='f8')
         self.compNGoodStarPerExp = np.zeros(self.nExp,dtype='i4')
+
+        self.compExpDeltaMagBkg = np.zeros(self.nExp, dtype='f8')
 
         # and sigFgcm
         self.compSigFgcm = np.zeros(self.nBands,dtype='f8')
@@ -437,6 +442,7 @@ class FgcmParameters(object):
         self.compRefSigma = np.atleast_1d(inParams['COMPREFSIGMA'][0])
         self.compMirrorChromaticity = inParams['COMPMIRRORCHROMATICITY'][0].reshape((self.nLUTFilter, self.nCoatingIntervals + 1))
         self.mirrorChromaticityPivot = np.atleast_1d(inParams['MIRRORCHROMATICITYPIVOT'][0])
+        self.compMedianSedSlope = np.atleast_1d(inParams['COMPMEDIANSEDSLOPE'][0])
 
         self.externalPwvFlag = np.zeros(self.nExp,dtype=np.bool)
         if self.hasExternalPwv:
@@ -471,6 +477,8 @@ class FgcmParameters(object):
         self.compExpGray = np.atleast_1d(inParams['COMPEXPGRAY'][0])
         self.compVarGray = np.atleast_1d(inParams['COMPVARGRAY'][0])
         self.compNGoodStarPerExp = np.atleast_1d(inParams['COMPNGOODSTARPEREXP'][0])
+
+        self.compExpDeltaMagBkg = np.atleast_1d(inParams['COMPEXPDELTAMAGBKG'][0])
 
         self.compSigFgcm = np.atleast_1d(inParams['COMPSIGFGCM'][0])
         self.compSigmaCal = np.atleast_1d(inParams['COMPSIGMACAL'][0])
@@ -937,6 +945,7 @@ class FgcmParameters(object):
                ('COMPREFSIGMA', 'f8', (self.compRefSigma.size, )),
                ('COMPMIRRORCHROMATICITY', 'f8', (self.compMirrorChromaticity.size, )),
                ('MIRRORCHROMATICITYPIVOT', 'f8', (self.mirrorChromaticityPivot.size, )),
+               ('COMPMEDIANSEDSLOPE', 'f8', (self.compMedianSedSlope.size, )),
                ('COMPAPERCORRPIVOT', 'f8', (self.compAperCorrPivot.size, )),
                ('COMPAPERCORRSLOPE', 'f8', (self.compAperCorrSlope.size, )),
                ('COMPAPERCORRSLOPEERR', 'f8', (self.compAperCorrSlopeErr.size, )),
@@ -947,6 +956,7 @@ class FgcmParameters(object):
                ('COMPMODELERRPARS', 'f8', (self.compModelErrPars.size, )),
                ('COMPEXPGRAY', 'f8', (self.compExpGray.size, )),
                ('COMPVARGRAY', 'f8', (self.compVarGray.size, )),
+               ('COMPEXPDELTAMAGBKG', 'f8', (self.compExpDeltaMagBkg.size, )),
                ('COMPNGOODSTARPEREXP', 'i4', (self.compNGoodStarPerExp.size, )),
                ('COMPSIGFGCM', 'f8', (self.compSigFgcm.size, )),
                ('COMPSIGMACAL', 'f8', (self.compSigmaCal.size, )),
@@ -985,6 +995,7 @@ class FgcmParameters(object):
         pars['COMPREFSIGMA'][:] = self.compRefSigma
         pars['COMPMIRRORCHROMATICITY'][:] = self.compMirrorChromaticity.flatten()
         pars['MIRRORCHROMATICITYPIVOT'][:] = self.mirrorChromaticityPivot
+        pars['COMPMEDIANSEDSLOPE'][:] = self.compMedianSedSlope
 
         if (self.hasExternalPwv):
             pars['PAREXTERNALLNPWVSCALE'] = self.parExternalLnPwvScale
@@ -1008,6 +1019,8 @@ class FgcmParameters(object):
         pars['COMPEXPGRAY'][:] = self.compExpGray
         pars['COMPVARGRAY'][:] = self.compVarGray
         pars['COMPNGOODSTARPEREXP'][:] = self.compNGoodStarPerExp
+
+        pars['COMPEXPDELTAMAGBKG'][:] = self.compExpDeltaMagBkg
 
         pars['COMPSIGFGCM'][:] = self.compSigFgcm
         pars['COMPSIGMACAL'][:] = self.compSigmaCal

--- a/fgcm/fgcmZeropoints.py
+++ b/fgcm/fgcmZeropoints.py
@@ -68,6 +68,7 @@ class FgcmZeropoints(object):
         self.expGrayRecoverCut = fgcmConfig.expGrayRecoverCut
         self.expGrayErrRecoverCut = fgcmConfig.expGrayErrRecoverCut
         self.expVarGrayPhotometricCut = fgcmConfig.expVarGrayPhotometricCut
+        self.deltaMagBkgPerCcd = fgcmConfig.deltaMagBkgPerCcd
         self.superStarSubCCD = fgcmConfig.superStarSubCCD
         self.seeingSubExposure = fgcmConfig.seeingSubExposure
         self.ccdGraySubCCD = fgcmConfig.ccdGraySubCCD
@@ -107,6 +108,7 @@ class FgcmZeropoints(object):
            'FGCM_FILTER': Delta-zeropoint due to the filter offset
            'FGCM_FLAT': Delta-zeropoint due to superStarFlat
            'FGCM_APERCORR': Delta-zeropoint due to aperture correction
+           'FGCM_DELTAMAGBKG': Delta-zeropoint due to background offset correction
            'FGCM_CTRANS': Transmission curve adjustment constant
            'EXPTIME': Exposure time (seconds)
            'FILTERNAME': Filter name
@@ -123,6 +125,7 @@ class FgcmZeropoints(object):
 
         # first, we need to get relevant quantities from shared memory.
         expGray = snmm.getArray(self.fgcmGray.expGrayHandle)
+        expDeltaStd = snmm.getArray(self.fgcmGray.expDeltaStdHandle)
         expGrayErr = snmm.getArray(self.fgcmGray.expGrayErrHandle)
         expGrayRMS = snmm.getArray(self.fgcmGray.expGrayRMSHandle)
         expNGoodCCDs = snmm.getArray(self.fgcmGray.expNGoodCCDsHandle)
@@ -132,6 +135,7 @@ class FgcmZeropoints(object):
         expGrayRMSColorSplit = snmm.getArray(self.fgcmGray.expGrayRMSColorSplitHandle)
 
         ccdGray = snmm.getArray(self.fgcmGray.ccdGrayHandle)
+        ccdDeltaStd = snmm.getArray(self.fgcmGray.ccdDeltaStdHandle)
         ccdGrayRMS = snmm.getArray(self.fgcmGray.ccdGrayRMSHandle)
         ccdGrayErr = snmm.getArray(self.fgcmGray.ccdGrayErrHandle)
         ccdNGoodStars = snmm.getArray(self.fgcmGray.ccdNGoodStarsHandle)
@@ -189,6 +193,8 @@ class FgcmZeropoints(object):
                       ('FGCM_FILTER','f8'),
                       ('FGCM_FLAT','f8'),
                       ('FGCM_APERCORR','f8'),
+                      ('FGCM_DELTAMAGBKG', 'f8'),
+                      ('FGCM_DELTACHROM', 'f8'),
                       ('FGCM_CTRANS', 'f4'),
                       ('EXPTIME','f4'),
                       ('FILTERNAME', 'a%d' % (maxFilterLen)),
@@ -249,6 +255,15 @@ class FgcmZeropoints(object):
             zpStruct['FGCM_APERCORR'][:] = self.fgcmPars.ccdApertureCorrection[zpExpIndex, zpCCDIndex]
         else:
             zpStruct['FGCM_APERCORR'][:] = self.fgcmPars.expApertureCorrection[zpExpIndex]
+
+        # Fill in the background correction
+        ccdDeltaMagBkg = snmm.getArray(self.fgcmGray.ccdDeltaMagBkgHandle)
+        if self.deltaMagBkgPerCcd:
+            ccdDeltaMagBkg = snmm.getArray(self.fgcmGray.ccdDeltaMagBkgHandle)
+            zpStruct['FGCM_DELTAMAGBKG'][:] = ccdDeltaMagBkg[zpExpIndex, zpCCDIndex]
+        else:
+            expDeltaMagBkg = snmm.getArray(self.fgcmGray.expDeltaMagBkgHandle)
+            zpStruct['FGCM_DELTAMAGBKG'][:] = expDeltaMagBkg[zpExpIndex]
 
         # Fill in the transmission adjustment constant
         zpStruct['FGCM_CTRANS'][:] = self.fgcmPars.expCTrans[zpExpIndex]
@@ -311,10 +326,18 @@ class FgcmZeropoints(object):
                                                          self.fgcmPars.expPmb[zpExpIndex],
                                                          lutIndices) / zpStruct['FGCM_I0'][:]
 
+        bad, = np.where((~np.isfinite(zpStruct['FGCM_I0'])) |
+                        (~np.isfinite(zpStruct['FGCM_I10'])))
+        if bad.size > 0:
+            self.fgcmLog.warn("There are %d ccds with bad I0/I10 values" % (bad.size))
+            zpStruct['FGCM_I0'][bad] = self.illegalValue
+            zpStruct['FGCM_I10'][bad] = self.illegalValue
+
         # Set the tilings, gray values, and zptvar
 
         zpStruct['FGCM_TILINGS'][:] = self.illegalValue
         zpStruct['FGCM_GRY'][:] = self.illegalValue
+        zpStruct['FGCM_DELTACHROM'][:] = self.illegalValue
         zpStruct['FGCM_ZPTVAR'][:] = self.illegalValue
 
         goodCCD, = np.where((ccdNGoodStars[zpExpIndex,zpCCDIndex] >=
@@ -325,6 +348,8 @@ class FgcmZeropoints(object):
                                                             zpCCDIndex[goodCCD]]
         zpStruct['FGCM_GRY'][goodCCD] = ccdGray[zpExpIndex[goodCCD],
                                                 zpCCDIndex[goodCCD]]
+        zpStruct['FGCM_DELTACHROM'][goodCCD] = ccdDeltaStd[zpExpIndex[goodCCD],
+                                                         zpCCDIndex[goodCCD]]
         zpStruct['FGCM_ZPTVAR'][goodCCD] = ccdGrayErr[zpExpIndex[goodCCD],
                                                       zpCCDIndex[goodCCD]]**2.
 
@@ -353,6 +378,7 @@ class FgcmZeropoints(object):
 
         zpStruct['FGCM_TILINGS'][badCCDGoodExp] = expNGoodTilings[zpExpIndex[badCCDGoodExp]]
         zpStruct['FGCM_GRY'][badCCDGoodExp] = expGray[zpExpIndex[badCCDGoodExp]]
+        zpStruct['FGCM_DELTACHROM'][badCCDGoodExp] = expDeltaStd[zpExpIndex[badCCDGoodExp]]
         # And fill in the chebyshev parameters if necessary
         if self.outputFgcmcalZpts and np.any(self.ccdGraySubCCD):
             # We need to alter the gray parameters to record the constant (interpolated)
@@ -442,6 +468,7 @@ class FgcmZeropoints(object):
                             (zpStruct['FGCM_DUST'][okZpIndex] > self.illegalValue) &
                             (zpStruct['FGCM_FILTER'][okZpIndex] > self.illegalValue) &
                             (zpStruct['FGCM_APERCORR'][okZpIndex] > self.illegalValue) &
+                            (zpStruct['FGCM_DELTAMAGBKG'][okZpIndex] > self.illegalValue) &
                             (zpStruct['FGCM_GRY'][okZpIndex] > self.illegalValue))
 
         okCCDZpIndex = okZpIndex[okCCDZpIndexFlag]
@@ -475,6 +502,7 @@ class FgcmZeropoints(object):
                              (zpStruct['FGCM_DUST'][mehZpIndex] > self.illegalValue) &
                              (zpStruct['FGCM_FILTER'][mehZpIndex] > self.illegalValue) &
                              (zpStruct['FGCM_APERCORR'][mehZpIndex] > self.illegalValue) &
+                             (zpStruct['FGCM_DELTAMAGBKG'][mehZpIndex] > self.illegalValue) &
                              (zpStruct['FGCM_GRY'][mehZpIndex] > self.illegalValue) &
                              (ccdNGoodStars[zpExpIndex[mehZpIndex],zpCCDIndex[mehZpIndex]] >=
                               self.minStarPerCCD) &
@@ -627,6 +655,7 @@ class FgcmZeropoints(object):
                 zpStruct['FGCM_DUST'][indices] +
                 zpStruct['FGCM_FILTER'][indices] +  # includes throughput correction
                 zpStruct['FGCM_APERCORR'][indices] +
+                zpStruct['FGCM_DELTAMAGBKG'][indices] +
                 2.5*np.log10(zpStruct['EXPTIME'][indices]) +
                 self.zptABNoThroughput +
                 grayValue)
@@ -700,48 +729,6 @@ class FgcmZeropoints(object):
         zptChebPars[:, :] = (zptChebPars.T * 10.**(self._computeZpt(zpStruct, zpIndex, includeFlat=False, includeGray=includeGray) / (-2.5))).T
 
         return zptChebPars, zptChebSstarPars
-
-    #def _combineChebyshevPolynomials(self, xSize, ySize, pars1, pars2):
-    #    """
-    #    Combine two chebyshev 2d fields empirically
-
-    #    parameters
-    #    ----------
-    #    xSize: int
-    #       size in x direction
-    #    ySize: int
-    #       size in y direction
-    #    pars1: float array, (order1 + 1), (order1 + 1)
-    #       chebyshev parameters for first polynomial
-    #    pars2: float array, (order2 + 1), (order2 + 1)
-    #       chebyshev parameters for second polynomial
-
-    #    returns
-    #    -------
-    #    pars: float array (self.nChebPar)
-    #    """
-
-        # Empirically combine two sets of chebyshev polynomials...
-        # self.nChebPar is number of parameters (order is sqrt(nChebPar) - 1)
-        # We are not going to require triangularity because of the combination
-        # might be better served with higher order terms
-        # self.combineChebTriangular whether it is triangular.
-
-    #    order = int(np.sqrt(self.nChebPar)) - 1
-
-    #    xPos = np.random.rand(self.combineNStar) * xSize
-    #    yPos = np.random.rand(self.combineNStar) * ySize
-
-    #    field1 = Cheb2dField(xSize, ySize, pars1)
-    #    value1 = field1.evaluate(xPos, yPos)
-    #    field2 = Cheb2dField(xSize, ySize, pars2)
-    #    value2 = field2.evaluate(xPos, yPos)
-
-    #    value = value1 * value2
-
-    #    field = Cheb2dField.fit(xSize, ySize, order, xPos, yPos, value, triangular=False)
-
-    #    return field.pars.flatten()
 
     def _computeZptErr(self,zpStruct,zpExpIndex,zpIndex):
         """

--- a/fgcm/fgcmZpsToApply.py
+++ b/fgcm/fgcmZpsToApply.py
@@ -38,6 +38,7 @@ class FgcmZpsToApply(object):
         self.ccdStartIndex = fgcmConfig.ccdStartIndex
         self.nStarPerRun = fgcmConfig.nStarPerRun
         self.quietMode = fgcmConfig.quietMode
+        self.hasDeltaMagBkg = fgcmStars.hasDeltaMagBkg
 
         self.I10StdBand = fgcmConfig.I10StdBand
 
@@ -61,10 +62,15 @@ class FgcmZpsToApply(object):
 
         zps = fitsio.read(self.zpsToApplyFile, ext='ZPTS', lower=True)
 
+        if self.hasDeltaMagBkg:
+            deltaMagOffset = zps['fgcm_deltabkgmag']
+        else:
+            deltaMagOffset = 0.0
+
         self.loadZeropoints(zps[self.expField.lower()],
                             zps[self.ccdField.lower()],
                             zps['fgcm_flag'],
-                            zps['fgcm_zpt'],
+                            zps['fgcm_zpt'] + deltaMagOffset,
                             zps['fgcm_i10'])
 
         del zps


### PR DESCRIPTION
Now fgcm will track offsets due to local background modeling if requested,
ensuring that the bright end is unaffected by background offsets.  Missing SED
slopes are now filled in to be "average" (rather than very blue!).  And the
average chromatic correction per ccd is recorded to get better repeatability
when using output zeropoints without chromatic corrections.