### PR TITLE
Add numerous minor fixes and update to 3.6.3

### DIFF
--- a/fgcm/_version.py
+++ b/fgcm/_version.py
@@ -1,3 +1,3 @@
-__version__ = '3.6.2'
+__version__ = '3.6.3'
 
 __version_info__ = __version__.split('.')

--- a/fgcm/fgcmChisq.py
+++ b/fgcm/fgcmChisq.py
@@ -832,7 +832,7 @@ class FgcmChisq(object):
         #  Compute derivatives...
 
         # Default mask is not to mask
-        maskGO = np.ones(goodObs.size, dtype=np.bool)
+        maskGO = np.ones(goodObs.size, dtype=bool)
 
         useRefstars = False
         if self.fgcmStars.hasRefstars and not self.ignoreRef:

--- a/fgcm/fgcmComputeStepUnits.py
+++ b/fgcm/fgcmComputeStepUnits.py
@@ -365,7 +365,7 @@ class FgcmComputeStepUnits(object):
         # Note that we don't care if something is a refstar or not for this
 
         # Default mask is not to mask
-        maskGO = np.ones(goodObs.size, dtype=np.bool)
+        maskGO = np.ones(goodObs.size, dtype=bool)
 
         # which observations are actually used in the fit?
         useGO, = np.where(maskGO)

--- a/fgcm/fgcmConfig.py
+++ b/fgcm/fgcmConfig.py
@@ -403,7 +403,7 @@ class FgcmConfig(object):
 
         # Cut the LUT filter names to those that are actually used
         usedFilterNames = self.filterToBand.keys()
-        usedLutFilterMark = np.zeros(len(self.lutFilterNames), dtype=np.bool)
+        usedLutFilterMark = np.zeros(len(self.lutFilterNames), dtype=bool)
         for i, f in enumerate(self.lutFilterNames):
             if f in usedFilterNames:
                 usedLutFilterMark[i] = True
@@ -467,7 +467,7 @@ class FgcmConfig(object):
 
         # read in the ccd offset file...also append a place to store sign/rotation
         dtype = ccdOffsets.dtype.descr
-        dtype.extend([('XRA', np.bool),
+        dtype.extend([('XRA', bool),
                       ('RASIGN', 'i2'),
                       ('DECSIGN', 'i2')])
 
@@ -492,9 +492,11 @@ class FgcmConfig(object):
         test=np.searchsorted(self.epochMJDs,self.mjdRange)
 
         if test.min() == 0:
-            raise ValueError("Exposure start MJD is out of epoch range!")
+            self.fgcmLog.warn("Exposure start MJD before epoch range.  Adding additional epoch.")
+            self.epochMJDs = np.insert(self.epochMJDs, 0, self.mjdRange[0] - 1.0)
         if test.max() == self.epochMJDs.size:
-            raise ValueError("Exposure end MJD is out of epoch range!")
+            self.fgcmLog.warn("Exposure end MJD after epoch range.  Adding additional epoch.")
+            self.epochMJDs = np.insert(self.epochMJDs, len(self.epochMJDs), self.mjdRange[1] + 1.0)
 
         # crop to valid range
         self.epochMJDs = self.epochMJDs[test[0]-1:test[1]+1]
@@ -519,7 +521,7 @@ class FgcmConfig(object):
         self.coatingMJDs = self.coatingMJDs[gd]
 
         # Deal with fit band, notfit band, required, and notrequired indices
-        bandFitFlag = np.zeros(len(self.bands), dtype=np.bool)
+        bandFitFlag = np.zeros(len(self.bands), dtype=bool)
         bandNotFitFlag = np.zeros_like(bandFitFlag)
         bandRequiredFlag = np.zeros_like(bandFitFlag)
 

--- a/fgcm/fgcmLUT.py
+++ b/fgcm/fgcmLUT.py
@@ -752,7 +752,7 @@ class FgcmLUT(object):
 
         # We cut down these to those filters that are defined in the map
         usedFilterNames = self.filterToBand.keys()
-        usedLutFilterMark = np.zeros(len(self.filterNames), dtype=np.bool)
+        usedLutFilterMark = np.zeros(len(self.filterNames), dtype=bool)
         for i, f in enumerate(self.filterNames):
             if f in usedFilterNames:
                 usedLutFilterMark[i] = True

--- a/fgcm/fgcmParameters.py
+++ b/fgcm/fgcmParameters.py
@@ -301,7 +301,7 @@ class FgcmParameters(object):
         # for the same band.  In the future we can add "primary absolute calibrators"
         # to the fit, and turn these on.
         self.parFilterOffset = np.zeros(self.nLUTFilter, dtype=np.float64)
-        self.parFilterOffsetFitFlag = np.zeros(self.nLUTFilter, dtype=np.bool)
+        self.parFilterOffsetFitFlag = np.zeros(self.nLUTFilter, dtype=bool)
         for i, f in enumerate(self.lutFilterNames):
             band = self.filterToBand[f]
             nBand = 0
@@ -329,14 +329,14 @@ class FgcmParameters(object):
         self.compMedianSedSlope = np.zeros(self.nBands, dtype=np.float64)
 
         ## FIXME: need to completely refactor
-        self.externalPwvFlag = np.zeros(self.nExp,dtype=np.bool)
+        self.externalPwvFlag = np.zeros(self.nExp,dtype=bool)
         if (self.pwvFile is not None):
             self.fgcmLog.info('Found external PWV file.')
             self.pwvFile = self.pwvFile
             self.hasExternalPwv = True
             self.loadExternalPwv(self.externalPwvDeltaT)
 
-        self.externalTauFlag = np.zeros(self.nExp,dtype=np.bool)
+        self.externalTauFlag = np.zeros(self.nExp,dtype=bool)
         if (self.tauFile is not None):
             self.fgcmLog.info('Found external tau file.')
             self.tauFile = self.tauFile
@@ -421,8 +421,8 @@ class FgcmParameters(object):
         self._loadEpochAndWashInfo()
 
         # look at external...
-        self.hasExternalPwv = inParInfo['HASEXTERNALPWV'][0].astype(np.bool)
-        self.hasExternalTau = inParInfo['HASEXTERNALTAU'][0].astype(np.bool)
+        self.hasExternalPwv = inParInfo['HASEXTERNALPWV'][0].astype(bool)
+        self.hasExternalTau = inParInfo['HASEXTERNALTAU'][0].astype(bool)
 
         ## and copy the parameters
         self.parAlpha = np.atleast_1d(inParams['PARALPHA'][0])
@@ -436,7 +436,7 @@ class FgcmParameters(object):
         self.compQESysSlope = inParams['COMPQESYSSLOPE'][0].reshape((self.nBands, self.nWashIntervals))
         self.compQESysSlopeApplied = self.compQESysSlope.copy()
         self.parFilterOffset = np.atleast_1d(inParams['PARFILTEROFFSET'][0])
-        self.parFilterOffsetFitFlag = np.atleast_1d(inParams['PARFILTEROFFSETFITFLAG'][0]).astype(np.bool)
+        self.parFilterOffsetFitFlag = np.atleast_1d(inParams['PARFILTEROFFSETFITFLAG'][0]).astype(bool)
         self.compAbsThroughput = np.atleast_1d(inParams['COMPABSTHROUGHPUT'][0])
         self.compRefOffset = np.atleast_1d(inParams['COMPREFOFFSET'][0])
         self.compRefSigma = np.atleast_1d(inParams['COMPREFSIGMA'][0])
@@ -444,7 +444,7 @@ class FgcmParameters(object):
         self.mirrorChromaticityPivot = np.atleast_1d(inParams['MIRRORCHROMATICITYPIVOT'][0])
         self.compMedianSedSlope = np.atleast_1d(inParams['COMPMEDIANSEDSLOPE'][0])
 
-        self.externalPwvFlag = np.zeros(self.nExp,dtype=np.bool)
+        self.externalPwvFlag = np.zeros(self.nExp,dtype=bool)
         if self.hasExternalPwv:
             self.pwvFile = str(inParInfo['PWVFILE'][0]).rstrip()
             self.hasExternalPwv = True
@@ -452,7 +452,7 @@ class FgcmParameters(object):
             self.parExternalLnPwvScale = inParams['PAREXTERNALLNPWVSCALE'][0]
             self.parExternalLnPwvOffset[:] = np.atleast_1d(inParams['PAREXTERNALLNPWVOFFSET'][0])
 
-        self.externalTauFlag = np.zeros(self.nExp,dtype=np.bool)
+        self.externalTauFlag = np.zeros(self.nExp,dtype=bool)
         if self.hasExternalTau:
             self.tauFile = str(inParInfo['TAUFILE'][0]).rstrip()
             self.hasExternalTau = True
@@ -650,8 +650,8 @@ class FgcmParameters(object):
         # link exposures to bands
         self.expBandIndex = np.zeros(self.nExp,dtype='i2') - 1
         self.expLUTFilterIndex = np.zeros(self.nExp,dtype='i2') - 1
-        self.hasExposuresInFilter = np.ones(self.nLUTFilter, dtype=np.bool)
-        self.hasExposuresInBand = np.zeros(self.nBands, dtype=np.bool)
+        self.hasExposuresInFilter = np.ones(self.nLUTFilter, dtype=bool)
+        self.hasExposuresInBand = np.zeros(self.nBands, dtype=bool)
         expFilterName = np.core.defchararray.strip(expInfo['FILTERNAME'])
 
         expFilterNameIsEncoded = False
@@ -687,7 +687,7 @@ class FgcmParameters(object):
             self.expFlag[bad] = self.expFlag[bad] | expFlagDict['BAND_NOT_IN_LUT']
 
         # Flag exposures that are not in the fit bands
-        self.expNotFitBandFlag = np.zeros(self.nExp, dtype=np.bool)
+        self.expNotFitBandFlag = np.zeros(self.nExp, dtype=bool)
         if self.nNotFitBands > 0:
             a, b = esutil.numpy_util.match(self.bandNotFitIndex, self.expBandIndex)
             self.expNotFitBandFlag[b] = True

--- a/fgcm/fgcmSigmaRef.py
+++ b/fgcm/fgcmSigmaRef.py
@@ -126,6 +126,8 @@ class FgcmSigmaRef(object):
                                    gmiGRS[okColor[st[-1]]]])
             gmiCutNames = ['All', 'Blue25', 'Middle50', 'Red25']
 
+            message = None
+
             for bandIndex, band in enumerate(self.fgcmStars.bands):
                 if not self.fgcmPars.hasExposuresInBand[bandIndex]:
                     continue

--- a/fgcm/fgcmStars.py
+++ b/fgcm/fgcmStars.py
@@ -377,7 +377,7 @@ class FgcmStars(object):
             self.fgcmLog.info('PSF Candidate Flags found')
 
             # psfCandidate: bool flag if this is a single-epoch psf candidate
-            self.psfCandidateHandle = snmm.createArray(self.nStarObs, dtype=np.bool)
+            self.psfCandidateHandle = snmm.createArray(self.nStarObs, dtype=bool)
         if obsDeltaMagBkg is not None:
             # Do not use if all 0s
             if np.min(obsDeltaMagBkg) != 0.0 and np.max(obsDeltaMagBkg) != 0.0:
@@ -469,6 +469,12 @@ class FgcmStars(object):
             else:
                 snmm.getArray(self.obsLUTFilterIndexHandle)[use] = filterIndex
                 snmm.getArray(self.obsBandIndexHandle)[use] = bandIndex
+
+        # Check for minimum number of bands
+        obsBandIndex = snmm.getArray(self.obsBandIndexHandle)
+        ok, = np.where(obsBandIndex >= 0)
+        if (len(np.unique(obsBandIndex[ok])) < 2):
+            raise NotImplementedError("Cannot run fgcmcal with fewer than 2 bands of data.")
 
         if not self.quietMode:
             self.fgcmLog.info('Observations matched in %.1f seconds.' %

--- a/fgcm/fgcmSuperStarFlat.py
+++ b/fgcm/fgcmSuperStarFlat.py
@@ -132,7 +132,7 @@ class FgcmSuperStarFlat(object):
         if not np.any(self.superStarSubCCD) or doNotUseSubCCD:
             # do not use subCCD x/y information (or x/y not available)
 
-            mark = np.ones(goodObs.size, dtype=np.bool)
+            mark = np.ones(goodObs.size, dtype=bool)
 
             # Next, we sort by epoch, band
             superStarWt = np.zeros_like(superStarFlatCenter)

--- a/fgcm/sharedNumpyMemManager.py
+++ b/fgcm/sharedNumpyMemManager.py
@@ -97,7 +97,7 @@ class SharedNumpyMemManager(object):
             ctype = ctypes.c_int64
         elif (dtype == np.int16):
             ctype = ctypes.c_int16
-        elif (dtype == np.bool):
+        elif (dtype == bool):
             ctype = ctypes.c_bool
         else:
             raise ValueError("Unsupported dtype")


### PR DESCRIPTION
Numpy deprecation warnings have been fixed, better errors when trying to fit with a single band, observations out of time range will trigger warnings rather than Raise, and a crash when no reference stars were matched in a band was fixed.