### PR TITLE
DM-36276: Add checks to not create empty hexbin log-scaled plots.

### DIFF
--- a/fgcm/_version.py
+++ b/fgcm/_version.py
@@ -1,3 +1,3 @@
-__version__ = '3.9.4'
+__version__ = '3.9.5'
 
 __version_info__ = __version__.split('.')

--- a/fgcm/fgcmGray.py
+++ b/fgcm/fgcmGray.py
@@ -1003,17 +1003,18 @@ class FgcmGray(object):
 
         deepUse,=np.where(self.fgcmPars.expDeepFlag[expUse] == 1)
 
-        ax.hexbin(self.fgcmPars.expMJD[expUse[deepUse]] - firstMJD,
-                  expGray[expUse[deepUse]]*1000.0, bins='log')
-        ax.set_xlabel(r'$\mathrm{MJD}\ -\ %.0f$' % (firstMJD),fontsize=16)
-        ax.set_ylabel(r'$\mathrm{EXP}^{\mathrm{gray}}\,(\mathrm{mmag})$',fontsize=16)
+        if deepUse.size > 0:
+            ax.hexbin(self.fgcmPars.expMJD[expUse[deepUse]] - firstMJD,
+                      expGray[expUse[deepUse]]*1000.0, bins='log')
+            ax.set_xlabel(r'$\mathrm{MJD}\ -\ %.0f$' % (firstMJD),fontsize=16)
+            ax.set_ylabel(r'$\mathrm{EXP}^{\mathrm{gray}}\,(\mathrm{mmag})$',fontsize=16)
 
-        ax.set_title(r'$\mathrm{Deep Fields}$')
+            ax.set_title(r'$\mathrm{Deep Fields}$')
 
-        if self.plotPath is not None:
-            fig.savefig('%s/%s_mjd_deep_expgray.png' % (self.plotPath,
-                                                        self.outfileBaseWithCycle))
-        plt.close(fig)
+            if self.plotPath is not None:
+                fig.savefig('%s/%s_mjd_deep_expgray.png' % (self.plotPath,
+                                                            self.outfileBaseWithCycle))
+            plt.close(fig)
 
         # And plot correlations of EXP^gray between pairs of bands
         for ind, bandIndex0 in enumerate(self.bandFitIndex[:-2]):

--- a/fgcm/fgcmMirrorChromaticity.py
+++ b/fgcm/fgcmMirrorChromaticity.py
@@ -149,45 +149,44 @@ class FgcmMirrorChromaticity(object):
                 ok, = np.where((expGrayColorSplitWt[:, 0] > 0.0) &
                                (expGrayColorSplitWt[:, 1] > 0.0))
 
-                deltaColorRaw = (expGrayColorSplitRaw[ok, 0] - expGrayColorSplitRaw[ok, 1]) * 1000.0
-                st = np.argsort(deltaColorRaw)
-                extent = [np.min(self.fgcmPars.expMJD[ok] - firstMJD),
-                          np.max(self.fgcmPars.expMJD[ok] - firstMJD),
-                          deltaColorRaw[st[int(0.01*deltaColorRaw.size)]],
-                          deltaColorRaw[st[int(0.99*deltaColorRaw.size)]]]
+                if ok.size > 0:
+                    deltaColorRaw = (expGrayColorSplitRaw[ok, 0] - expGrayColorSplitRaw[ok, 1]) * 1000.0
+                    st = np.argsort(deltaColorRaw)
+                    extent = [np.min(self.fgcmPars.expMJD[ok] - firstMJD),
+                              np.max(self.fgcmPars.expMJD[ok] - firstMJD),
+                              deltaColorRaw[st[int(0.01*deltaColorRaw.size)]],
+                              deltaColorRaw[st[int(0.99*deltaColorRaw.size)]]]
 
-                plt.set_cmap('viridis')
+                    plt.set_cmap('viridis')
 
-                fig = plt.figure(1, figsize=(8, 6))
-                fig.clf()
+                    fig = plt.figure(1, figsize=(8, 6))
+                    fig.clf()
 
-                ax = fig.add_subplot(111)
-                ax.hexbin(self.fgcmPars.expMJD[ok] - firstMJD,
-                          (expGrayColorSplitRaw[ok, 0] - expGrayColorSplitRaw[ok, 1]) * 1000.0,
-                          bins='log', extent=extent)
+                    ax = fig.add_subplot(111)
+                    ax.hexbin(self.fgcmPars.expMJD[ok] - firstMJD,
+                              (expGrayColorSplitRaw[ok, 0] - expGrayColorSplitRaw[ok, 1]) * 1000.0,
+                              bins='log', extent=extent)
 
-                ylim = ax.get_ylim()
-                for i in range(self.fgcmPars.nCoatingIntervals):
-                    ax.plot([self.fgcmPars.coatingMJDs[i] - firstMJD,
-                             self.fgcmPars.coatingMJDs[i] - firstMJD],
-                            ylim, 'r--')
-                    u, = np.where(self.fgcmPars.expCoatingIndex[ok] == i)
-                    ax.plot(self.fgcmPars.expMJD[ok[u]] - firstMJD, delta[ok[u]] * 1000.0, 'r--')
-                ax.set_xlabel('MJD - %.0f' % (firstMJD))
-                ax.set_ylabel('EXP_GRAY (%s) (red25) - EXP_GRAY (%s) (blue25) (mmag)' %
-                              (self.fgcmPars.lutFilterNames[filterIndex],
-                               self.fgcmPars.lutFilterNames[filterIndex]))
+                    ylim = ax.get_ylim()
+                    for i in range(self.fgcmPars.nCoatingIntervals):
+                        ax.plot([self.fgcmPars.coatingMJDs[i] - firstMJD,
+                                 self.fgcmPars.coatingMJDs[i] - firstMJD],
+                                ylim, 'r--')
+                        u, = np.where(self.fgcmPars.expCoatingIndex[ok] == i)
+                        ax.plot(self.fgcmPars.expMJD[ok[u]] - firstMJD, delta[ok[u]] * 1000.0, 'r--')
+                    ax.set_xlabel('MJD - %.0f' % (firstMJD))
+                    ax.set_ylabel('EXP_GRAY (%s) (red25) - EXP_GRAY (%s) (blue25) (mmag)' %
+                                  (self.fgcmPars.lutFilterNames[filterIndex],
+                                   self.fgcmPars.lutFilterNames[filterIndex]))
 
-                text=r'$(%s)$' % (self.fgcmPars.lutFilterNames[filterIndex])
-                ax.annotate(text,(0.95,0.93),xycoords='axes fraction',ha='right',va='top',fontsize=16)
+                    text=r'$(%s)$' % (self.fgcmPars.lutFilterNames[filterIndex])
+                    ax.annotate(text,(0.95,0.93),xycoords='axes fraction',ha='right',va='top',fontsize=16)
 
-                plt.savefig('%s/%s_compare-redblue-mirrorchrom_%s.png' % (self.plotPath,
-                                                                          self.outfileBaseWithCycle,
-                                                                          self.fgcmPars.lutFilterNames[filterIndex]))
+                    plt.savefig('%s/%s_compare-redblue-mirrorchrom_%s.png' % (self.plotPath,
+                                                                              self.outfileBaseWithCycle,
+                                                                              self.fgcmPars.lutFilterNames[filterIndex]))
 
-                plt.close(fig)
-
-
+                    plt.close(fig)
 
         # Clear things out of memory
         self.blueStarsInFilter = None


### PR DESCRIPTION
These plots crash in matplotlib 3.6.0 (though this is a bug in matplotlib), but why create these empty plots anyway?