### PR TITLE
Update for use with numpy 1.25/1.26

### DIFF
--- a/fgcm/_version.py
+++ b/fgcm/_version.py
@@ -1,3 +1,3 @@
-__version__ = '3.10.3'
+__version__ = '3.11.0'
 
 __version_info__ = __version__.split('.')

--- a/fgcm/fgcmBrightObs.py
+++ b/fgcm/fgcmBrightObs.py
@@ -217,7 +217,7 @@ class FgcmBrightObs(object):
         # find the brightest (minmag) object at each index
         np.fmin.at(objMagStdMeanTemp,
                    (obsObjIDIndexGO, obsBandIndexGO),
-                   obsMagStdGO)
+                   obsMagStdGO.astype(objMagStdMeanTemp.dtype))
 
         # now which observations are bright *enough* to consider?
         brightEnoughGO, = np.where((obsMagStdGO -
@@ -236,11 +236,11 @@ class FgcmBrightObs(object):
         np.add.at(wtSum,
                   (obsObjIDIndexGO[brightEnoughGO],
                    obsBandIndexGO[brightEnoughGO]),
-                  1./obsMagErr2GOBE)
+                  1./obsMagErr2GOBE.astype(wtSum.dtype))
         np.add.at(objMagStdMeanTemp,
                   (obsObjIDIndexGO[brightEnoughGO],
                    obsBandIndexGO[brightEnoughGO]),
-                  obsMagStdGO[brightEnoughGO]/obsMagErr2GOBE)
+                  (obsMagStdGO[brightEnoughGO]/obsMagErr2GOBE).astype(objMagStdMeanTemp.dtype))
         np.add.at(objNGoodObsTemp,
                   (obsObjIDIndexGO[brightEnoughGO],
                    obsBandIndexGO[brightEnoughGO]),

--- a/fgcm/fgcmChisq.py
+++ b/fgcm/fgcmChisq.py
@@ -640,10 +640,10 @@ class FgcmChisq(object):
 
             add_at_2d(wtSum,
                    (obsObjIDIndexGO,obsBandIndexGO),
-                   1./obsMagErr2GO)
+                   (1./obsMagErr2GO).astype(wtSum.dtype))
             add_at_2d(objMagStdMeanTemp,
                    (obsObjIDIndexGO,obsBandIndexGO),
-                   obsMagGO/obsMagErr2GO)
+                   (obsMagGO/obsMagErr2GO).astype(objMagStdMeanTemp.dtype))
 
             # these are good object/bands that were observed
             gd=np.where(wtSum > 0.0)
@@ -707,16 +707,16 @@ class FgcmChisq(object):
 
         add_at_2d(wtSum,
                (obsObjIDIndexGO,obsBandIndexGO),
-               1./obsMagErr2GO)
+               (1./obsMagErr2GO).astype(wtSum.dtype))
 
         add_at_2d(objMagStdMeanTemp,
                (obsObjIDIndexGO,obsBandIndexGO),
-               obsMagStdGO/obsMagErr2GO)
+               (obsMagStdGO/obsMagErr2GO).astype(objMagStdMeanTemp.dtype))
 
         # And the same thing with the non-chromatic corrected values
         add_at_2d(objMagStdMeanNoChromTemp,
                (obsObjIDIndexGO,obsBandIndexGO),
-               obsMagGO/obsMagErr2GO)
+               (obsMagGO/obsMagErr2GO).astype(objMagStdMeanNoChromTemp.dtype))
 
         # which objects/bands have observations?
         gd=np.where(wtSum > 0.0)
@@ -993,7 +993,7 @@ class FgcmChisq(object):
                 sumNumerator[:, :, :] = 0.0
                 add_at_3d(sumNumerator,
                           (gsGOF, obsBandIndexGOFI, expNightIndexGOFI),
-                          dLdO3GO[obsFitUseGOI] / obsMagErr2GOFI)
+                          (dLdO3GO[obsFitUseGOI] / obsMagErr2GOFI).astype(np.float64))
 
                 innerTermGOF[:] = 0.0
                 innerTermGOF[indGOF] = (dLdO3GO[obsFitUseGOI] -
@@ -1003,7 +1003,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parO3Loc +
                                             self.fgcmPars.nCampaignNights)],
                           expNightIndexGOF,
-                          2.0 * deltaMagWeightedGOF * innerTermGOF)
+                          (2.0 * deltaMagWeightedGOF * innerTermGOF).astype(np.float64))
 
                 partialArray[self.fgcmPars.parO3Loc +
                              uNightIndex] /= units[self.fgcmPars.parO3Loc +
@@ -1023,7 +1023,7 @@ class FgcmChisq(object):
                                                 self.fgcmPars.parO3Loc +
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGROF,
-                              2.0 * deltaRefMagWeightedGROF * dLdO3GO[goodRefObsGOF])
+                              (2.0 * deltaRefMagWeightedGROF * dLdO3GO[goodRefObsGOF]).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parO3Loc +
@@ -1040,7 +1040,7 @@ class FgcmChisq(object):
                 sumNumerator[:, :, :] = 0.0
                 add_at_3d(sumNumerator,
                           (gsGOF, obsBandIndexGOFI, expNightIndexGOFI),
-                          dLdAlphaGO[obsFitUseGOI] / obsMagErr2GOFI)
+                          (dLdAlphaGO[obsFitUseGOI] / obsMagErr2GOFI).astype(np.float64))
 
                 innerTermGOF[:] = 0.0
                 innerTermGOF[indGOF] = (dLdAlphaGO[obsFitUseGOI] -
@@ -1050,7 +1050,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parAlphaLoc+
                                             self.fgcmPars.nCampaignNights)],
                           expNightIndexGOF,
-                          2.0 * deltaMagWeightedGOF * innerTermGOF)
+                          (2.0 * deltaMagWeightedGOF * innerTermGOF).astype(np.float64))
 
                 partialArray[self.fgcmPars.parAlphaLoc +
                              uNightIndex] /= units[self.fgcmPars.parAlphaLoc +
@@ -1067,7 +1067,7 @@ class FgcmChisq(object):
                                                 self.fgcmPars.parAlphaLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGROF,
-                              2.0 * deltaRefMagWeightedGROF * dLdAlphaGO[goodRefObsGOF])
+                              (2.0 * deltaRefMagWeightedGROF * dLdAlphaGO[goodRefObsGOF]).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parAlphaLoc +
@@ -1093,8 +1093,8 @@ class FgcmChisq(object):
                               (gsGOF[hasExtGOFG],
                                obsBandIndexGOFI[hasExtGOFG],
                                expNightIndexGOFI[hasExtGOFG]),
-                              dLdLnPwvGO[obsFitUseGOI[hasExtGOFG]] /
-                              obsMagErr2GOFI[hasExtGOFG])
+                              (dLdLnPwvGO[obsFitUseGOI[hasExtGOFG]] /
+                               obsMagErr2GOFI[hasExtGOFG]).astype(np.float64))
 
                     innerTermGOF[:] = 0.0
                     innerTermGOF[indGOF[hasExtGOFG]] = (dLdLnPwvGO[obsFitUseGOI[hasExtGOFG]] -
@@ -1107,7 +1107,7 @@ class FgcmChisq(object):
                                                (self.fgcmPars.parExternalLnPwvOffsetLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGOF[hasExtGOF],
-                              2.0 * deltaMagWeightedGOF[hasExtGOF] * innerTermGOF[hasExtGOF])
+                              (2.0 * deltaMagWeightedGOF[hasExtGOF] * innerTermGOF[hasExtGOF]).astype(np.float64))
 
                     partialArray[self.fgcmPars.parExternalLnPwvOffsetLoc +
                                  uNightIndexHasExt] /= units[self.fgcmPars.parExternalLnPwvOffsetLoc +
@@ -1126,8 +1126,8 @@ class FgcmChisq(object):
                                                  self.fgcmPars.parExternalLnPwvOffsetLoc +
                                                  self.fgcmPars.nCampaignNights)],
                                expNightIndexGROF[hasExtGROF],
-                               2.0 * deltaRefMagWeightedGROF[hasExtGROF] *
-                               dLdLnPwvGO[goodRefObsGOF[hasExtGROF]])
+                               (2.0 * deltaRefMagWeightedGROF[hasExtGROF] *
+                                dLdLnPwvGO[goodRefObsGOF[hasExtGROF]]).astype(np.float64))
 
                         partialArray[2*self.fgcmPars.nFitPars +
                                      self.fgcmPars.parExternalLnPwvOffsetLoc +
@@ -1208,8 +1208,8 @@ class FgcmChisq(object):
                                       (gsGOF[hasRetrievedPwvGOFG],
                                        obsBandIndexGOFI[hasRetrievedPwvGOFG],
                                        expNightIndexGOFI[hasRetrievedPwvGOFG]),
-                                      dLdLnPwvGO[obsFitUseGOI[hasRetrievedPwvGOFG]] /
-                                      obsMagErr2GOFI[hasRetrievedPwvGOFG])
+                                      (dLdLnPwvGO[obsFitUseGOI[hasRetrievedPwvGOFG]] /
+                                       obsMagErr2GOFI[hasRetrievedPwvGOFG]).astype(np.float64))
 
                             innerTermGOF[:] = 0.0
                             innerTermGOF[indGOF[hasRetrievedPwvGOFG]] = (dLdLnPwvGO[obsFitUseGOI[hasRetrievedPwvGOFG]] -
@@ -1221,7 +1221,7 @@ class FgcmChisq(object):
                             add_at_1d(partialArray[self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc:
                                                        (self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc+
                                                         self.fgcmPars.nCampaignNights)],
-                                      2.0 * deltaMagWeightedGOF[hasRetrievedPwvGOF] * innerTermGOF[hasRetrievedPwvGOF])
+                                      (2.0 * deltaMagWeightedGOF[hasRetrievedPwvGOF] * innerTermGOF[hasRetrievedPwvGOF]).astype(np.float64))
 
                             partialArray[self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc +
                                          uNightIndexHasRetrievedPwv] /= units[self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc +
@@ -1239,8 +1239,8 @@ class FgcmChisq(object):
                                                          self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc+
                                                          self.fgcmPars.nCampaignNights)],
                                        expNightIndexGROF[hasRetrievedPwvGROF],
-                                       2.0 * deltaRefMagWeightedGROF *
-                                       dLdLnPwvGO[goodRefObsGOF[hasRetrievedPwvGROF]])
+                                       (2.0 * deltaRefMagWeightedGROF *
+                                       dLdLnPwvGO[goodRefObsGOF[hasRetrievedPwvGROF]]).astype(np.float64))
 
                                 partialArray[2*self.fgcmPars.nFitPars +
                                              self.fgcmPars.parRetrievedLnPwvNightlyOffsetLoc +
@@ -1289,8 +1289,8 @@ class FgcmChisq(object):
                               (gsGOF[noExtGOFG],
                                obsBandIndexGOFI[noExtGOFG],
                                expNightIndexGOFI[noExtGOFG]),
-                              dLdLnPwvGO[obsFitUseGOI[noExtGOFG]] /
-                              obsMagErr2GOFI[noExtGOFG])
+                              (dLdLnPwvGO[obsFitUseGOI[noExtGOFG]] /
+                              obsMagErr2GOFI[noExtGOFG]).astype(np.float64))
 
                     innerTermGOF[:] = 0.0
                     innerTermGOF[indGOF[noExtGOFG]] = (dLdLnPwvGO[obsFitUseGOI[noExtGOFG]] -
@@ -1303,7 +1303,7 @@ class FgcmChisq(object):
                                                (self.fgcmPars.parLnPwvInterceptLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGOF[noExtGOF],
-                              2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF])
+                              (2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF]).astype(np.float64))
 
                     partialArray[self.fgcmPars.parLnPwvInterceptLoc +
                                  uNightIndexNoExt] /= units[self.fgcmPars.parLnPwvInterceptLoc +
@@ -1322,8 +1322,8 @@ class FgcmChisq(object):
                                                     self.fgcmPars.parLnPwvInterceptLoc+
                                                     self.fgcmPars.nCampaignNights)],
                                   expNightIndexGROF[noExtGROF],
-                                  2.0 * deltaRefMagWeightedGROF[noExtGROF] *
-                                  dLdLnPwvGO[goodRefObsGOF[noExtGROF]])
+                                  (2.0 * deltaRefMagWeightedGROF[noExtGROF] *
+                                  dLdLnPwvGO[goodRefObsGOF[noExtGROF]]).astype(np.float64))
 
                         partialArray[2*self.fgcmPars.nFitPars + self.fgcmPars.parLnPwvInterceptLoc + uRefNightIndexNoExt] = units[self.fgcmPars.parLnPwvInterceptLoc + uRefNightIndexNoExt]
                         partialArray[3*self.fgcmPars.nFitPars + self.fgcmPars.parLnPwvInterceptLoc + uRefNightIndexNoExt] += 1
@@ -1338,7 +1338,7 @@ class FgcmChisq(object):
                                obsBandIndexGOFI[noExtGOFG],
                                expNightIndexGOFI[noExtGOFG]),
                               (dLdLnPwvSlopeGOFI[noExtGOFG] /
-                               obsMagErr2GOFI[noExtGOFG]))
+                               obsMagErr2GOFI[noExtGOFG]).astype(np.float64))
 
                     innerTermGOF[:] = 0.0
                     innerTermGOF[indGOF[noExtGOFG]] = (dLdLnPwvSlopeGOFI[noExtGOFG] -
@@ -1350,7 +1350,7 @@ class FgcmChisq(object):
                                                (self.fgcmPars.parLnPwvSlopeLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGOF[noExtGOF],
-                              2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF])
+                              (2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF]).astype(np.float64))
 
                     partialArray[self.fgcmPars.parLnPwvSlopeLoc +
                                  uNightIndexNoExt] /= units[self.fgcmPars.parLnPwvSlopeLoc +
@@ -1366,9 +1366,9 @@ class FgcmChisq(object):
                                                     self.fgcmPars.parLnPwvSlopeLoc+
                                                     self.fgcmPars.nCampaignNights)],
                                   expNightIndexGROF[noExtGROF],
-                                  2.0 * deltaRefMagWeightedGROF[noExtGROF] *
+                                  (2.0 * deltaRefMagWeightedGROF[noExtGROF] *
                                   self.fgcmPars.expDeltaUT[obsExpIndexGO[goodRefObsGOF[noExtGROF]]] *
-                                  dLdLnPwvGO[goodRefObsGOF[noExtGROF]])
+                                  dLdLnPwvGO[goodRefObsGOF[noExtGROF]]).astype(np.float64))
 
                         partialArray[2*self.fgcmPars.nFitPars +
                                      self.fgcmPars.parLnPwvSlopeLoc +
@@ -1390,7 +1390,7 @@ class FgcmChisq(object):
                                    obsBandIndexGOFI[noExtGOFG],
                                    expNightIndexGOFI[noExtGOFG]),
                                   (dLdLnPwvQuadraticGOFI[noExtGOFG] /
-                                   obsMagErr2GOFI[noExtGOFG]))
+                                   obsMagErr2GOFI[noExtGOFG]).astype(np.float64))
 
                         innerTermGOF = np.zeros(obsFitUseGO.size)
                         innerTermGOF[:] = 0.0
@@ -1404,7 +1404,7 @@ class FgcmChisq(object):
                                                    (self.fgcmPars.parLnPwvQuadraticLoc+
                                                     self.fgcmPars.nCampaignNights)],
                                   expNightIndexGOF[noExtGOF],
-                                  2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF])
+                                  (2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF]).astype(np.float64))
                         partialArray[self.fgcmPars.parLnPwvQuadraticLoc +
                                      uNightIndexNoExt] /= units[self.fgcmPars.parLnPwvQuadraticLoc +
                                                                 uNightIndexNoExt]
@@ -1419,9 +1419,9 @@ class FgcmChisq(object):
                                                         self.fgcmPars.parLnPwvQuadraticLoc+
                                                         self.fgcmPars.nCampaignNights)],
                                       expNightIndexGROF[noExtGROF],
-                                      2.0 * deltaRefMagWeightedGROF[noExtGROF] *
+                                      (2.0 * deltaRefMagWeightedGROF[noExtGROF] *
                                       self.fgcmPars.expDeltaUT[obsExpIndexGO[goodRefObsGOF[noExtGROF]]]**2. *
-                                      dLdLnPwvGO[goodRefObsGOF[noExtGROF]])
+                                      dLdLnPwvGO[goodRefObsGOF[noExtGROF]]).astype(np.float64))
 
                             partialArray[2*self.fgcmPars.nFitPars +
                                          self.fgcmPars.parLnPwvQuadraticLoc +
@@ -1455,8 +1455,8 @@ class FgcmChisq(object):
                           (gsGOF[noExtGOFG],
                            obsBandIndexGOFI[noExtGOFG],
                            expNightIndexGOFI[noExtGOFG]),
-                          dLdLnTauGO[obsFitUseGOI[noExtGOFG]] /
-                          obsMagErr2GOFI[noExtGOFG])
+                          (dLdLnTauGO[obsFitUseGOI[noExtGOFG]] /
+                          obsMagErr2GOFI[noExtGOFG]).astype(np.float64))
 
                 innerTermGOF = np.zeros(obsFitUseGO.size)
                 innerTermGOF[:] = 0.0
@@ -1469,7 +1469,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parLnTauInterceptLoc+
                                             self.fgcmPars.nCampaignNights)],
                           expNightIndexGOF[noExtGOF],
-                          2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF])
+                          (2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF]).astype(np.float64))
 
                 partialArray[self.fgcmPars.parLnTauInterceptLoc +
                              uNightIndexNoExt] /= units[self.fgcmPars.parLnTauInterceptLoc +
@@ -1488,8 +1488,8 @@ class FgcmChisq(object):
                                                 self.fgcmPars.parLnTauInterceptLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGROF[noExtGROF],
-                              2.0 * deltaRefMagWeightedGROF[noExtGROF] *
-                              dLdLnTauGO[goodRefObsGOF[noExtGROF]])
+                              (2.0 * deltaRefMagWeightedGROF[noExtGROF] *
+                              dLdLnTauGO[goodRefObsGOF[noExtGROF]]).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parLnTauInterceptLoc +
@@ -1508,7 +1508,7 @@ class FgcmChisq(object):
                            obsBandIndexGOFI[noExtGOFG],
                            expNightIndexGOFI[noExtGOFG]),
                           (dLdLnTauSlopeGOFI[noExtGOFG] /
-                           obsMagErr2GOFI[noExtGOFG]))
+                           obsMagErr2GOFI[noExtGOFG]).astype(np.float64))
 
                 innerTermGOF[:] = 0.0
                 innerTermGOF[indGOF[noExtGOFG]] = (dLdLnTauSlopeGOFI[noExtGOFG] -
@@ -1520,7 +1520,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parLnTauSlopeLoc+
                                             self.fgcmPars.nCampaignNights)],
                           expNightIndexGOF[noExtGOF],
-                          2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF])
+                          (2.0 * deltaMagWeightedGOF[noExtGOF] * innerTermGOF[noExtGOF]).astype(np.float64))
 
                 partialArray[self.fgcmPars.parLnTauSlopeLoc +
                              uNightIndexNoExt] /= units[self.fgcmPars.parLnTauSlopeLoc +
@@ -1536,9 +1536,9 @@ class FgcmChisq(object):
                                                 self.fgcmPars.parLnTauSlopeLoc+
                                                 self.fgcmPars.nCampaignNights)],
                               expNightIndexGROF[noExtGROF],
-                              2.0 * deltaRefMagWeightedGROF[noExtGROF] *
+                              (2.0 * deltaRefMagWeightedGROF[noExtGROF] *
                               self.fgcmPars.expDeltaUT[obsExpIndexGO[goodRefObsGOF[noExtGROF]]] *
-                              dLdLnTauGO[goodRefObsGOF[noExtGROF]])
+                              dLdLnTauGO[goodRefObsGOF[noExtGROF]]).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parLnTauSlopeLoc +
@@ -1572,7 +1572,7 @@ class FgcmChisq(object):
                 sumNumerator = np.zeros((goodStars.size, self.fgcmPars.nBands, self.fgcmPars.parQESysIntercept.size))
                 add_at_3d(sumNumerator,
                           (gsGOF, obsBandIndexGOFI, ravelIndexGOF[indGOF]),
-                          1.0 / obsMagErr2GOFI)
+                          (1.0 / obsMagErr2GOFI).astype(np.float64))
 
                 innerTermGOF[:] = 0.0
                 innerTermGOF[indGOF] = (1.0 - sumNumerator[gsGOF,
@@ -1584,7 +1584,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parQESysInterceptLoc +
                                             self.fgcmPars.parQESysIntercept.size)],
                           ravelIndexGOF,
-                          2.0 * deltaMagWeightedGOF * innerTermGOF)
+                          (2.0 * deltaMagWeightedGOF * innerTermGOF).astype(np.float64))
 
                 partialArray[self.fgcmPars.parQESysInterceptLoc +
                              uWashBandIndex] /= units[self.fgcmPars.parQESysInterceptLoc +
@@ -1603,7 +1603,7 @@ class FgcmChisq(object):
                               np.ravel_multi_index((obsBandIndexGO[goodRefObsGOF],
                                                     esutil.numpy_util.to_native(self.fgcmPars.expWashIndex[obsExpIndexGO[goodRefObsGOF]])),
                                                    self.fgcmPars.parQESysIntercept.shape),
-                              2.0 * deltaRefMagWeightedGROF)
+                              (2.0 * deltaRefMagWeightedGROF).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parQESysInterceptLoc +
@@ -1620,7 +1620,7 @@ class FgcmChisq(object):
                 sumNumerator = np.zeros((goodStars.size, self.fgcmPars.nBands, self.fgcmPars.nWashIntervals))
                 add_at_3d(sumNumerator,
                           (gsGOF, obsBandIndexGOFI, expWashIndexGOF[indGOF]),
-                          1.0 / obsMagErr2GOFI)
+                          (1.0 / obsMagErr2GOFI).astype(np.float64))
 
                 innerTermGOF[:] = 0.0
                 innerTermGOF[indGOF] = (1.0 - sumNumerator[gsGOF,
@@ -1631,7 +1631,7 @@ class FgcmChisq(object):
                                            (self.fgcmPars.parQESysInterceptLoc +
                                             self.fgcmPars.nWashIntervals)],
                           expWashIndexGOF,
-                          2.0 * deltaMagWeightedGOF * innerTermGOF)
+                          (2.0 * deltaMagWeightedGOF * innerTermGOF).astype(np.float64))
 
                 partialArray[self.fgcmPars.parQESysInterceptLoc +
                              uWashIndex] /= units[self.fgcmPars.parQESysInterceptLoc +
@@ -1651,7 +1651,7 @@ class FgcmChisq(object):
                                                 self.fgcmPars.parQESysInterceptLoc +
                                                 self.fgcmPars.nWashIntervals)],
                               esutil.numpy_util.to_native(self.fgcmPars.expWashIndex[obsExpIndexGO[goodRefObsGOF]]),
-                              2.0 * deltaRefMagWeightedGROF)
+                              (2.0 * deltaRefMagWeightedGROF).astype(np.float64))
 
                     partialArray[2*self.fgcmPars.nFitPars +
                                  self.fgcmPars.parQESysInterceptLoc +
@@ -1668,7 +1668,7 @@ class FgcmChisq(object):
             sumNumerator = np.zeros((goodStars.size, self.fgcmPars.nBands, self.fgcmPars.nLUTFilter))
             add_at_3d(sumNumerator,
                       (gsGOF, obsBandIndexGOFI, obsLUTFilterIndexGO[obsFitUseGOI]),
-                      1.0 / obsMagErr2GOFI)
+                      (1.0 / obsMagErr2GOFI).astype(np.float64))
 
             innerTermGOF[:] = 0.0
             innerTermGOF[indGOF] = (1.0 - sumNumerator[gsGOF,
@@ -1680,7 +1680,7 @@ class FgcmChisq(object):
                                        (self.fgcmPars.parFilterOffsetLoc +
                                         self.fgcmPars.nLUTFilter)],
                       obsLUTFilterIndexGO[obsFitUseGO],
-                      2.0 * deltaMagWeightedGOF * innerTermGOF)
+                      (2.0 * deltaMagWeightedGOF * innerTermGOF).astype(np.float64))
             partialArray[self.fgcmPars.parFilterOffsetLoc:
                              (self.fgcmPars.parFilterOffsetLoc +
                               self.fgcmPars.nLUTFilter)] /= units[self.fgcmPars.parFilterOffsetLoc:

--- a/fgcm/fgcmChisq.py
+++ b/fgcm/fgcmChisq.py
@@ -8,6 +8,7 @@ from .fgcmUtilities import retrievalFlagDict
 from .fgcmUtilities import MaxFitIterations
 from .fgcmUtilities import Cheb2dField
 from .fgcmUtilities import objFlagDict
+from .fgcmUtilities import histogram_rev_sorted
 
 from .fgcmNumbaUtilities import numba_test, add_at_1d, add_at_2d, add_at_3d
 
@@ -606,7 +607,7 @@ class FgcmChisq(object):
                 obsYGO = snmm.getArray(self.fgcmStars.obsYHandle)[goodObs]
                 expCcdHash = (obsExpIndexGO[ok] * (self.fgcmPars.nCCD + 1) +
                               obsCCDIndexGO[ok])
-                h, rev = esutil.stat.histogram(expCcdHash, rev=True)
+                h, rev = histogram_rev_sorted(expCcdHash)
                 use, = np.where(h > 0)
                 for i in use:
                     i1a = rev[rev[i]: rev[i + 1]]

--- a/fgcm/fgcmChromaticity.py
+++ b/fgcm/fgcmChromaticity.py
@@ -382,7 +382,7 @@ class FgcmCCDChromaticity:
                 self.fgcmLog.warning("Found out-of-bounds value for chromaticity for filter %s, detector %d." % (self.fgcmPars.lutFilterNames[self.fInd], self.cInd + self.ccdStartIndex))
                 continue
 
-            self.fgcmPars.compCCDChromaticity[self.cInd, self.fInd] = res.x
+            self.fgcmPars.compCCDChromaticity[self.cInd, self.fInd] = res.x[0]
             cWasFit[self.cInd, self.fInd] = True
 
         # And make plots if necessary.

--- a/fgcm/fgcmChromaticity.py
+++ b/fgcm/fgcmChromaticity.py
@@ -227,10 +227,10 @@ class FgcmMirrorChromaticity(object):
 
             np.add.at(expGrayColorSplit[:, k],
                       self.obsExpIndexGO[sel],
-                      EGrayGOS / self.EGrayErr2GO[sel])
+                      (EGrayGOS / self.EGrayErr2GO[sel]).astype(expGrayColorSplit.dtype))
             np.add.at(expGrayColorSplitWt[:, k],
                       self.obsExpIndexGO[sel],
-                      1. / self.EGrayErr2GO[sel])
+                      (1. / self.EGrayErr2GO[sel]).astype(expGrayColorSplitWt.dtype))
 
             ok, = np.where(expGrayColorSplitWt[:, k] > 0.0)
             expGrayColorSplit[ok, k] /= expGrayColorSplitWt[ok, k]
@@ -241,14 +241,14 @@ class FgcmMirrorChromaticity(object):
 
             np.add.at(dExpGraydC0ColorSplit[:, :, k],
                       (self.obsExpIndexGO[sel], self.fgcmPars.expCoatingIndex[self.obsExpIndexGO[sel]]),
-                      dDeltadC0GOS / self.EGrayErr2GO[sel])
+                      (dDeltadC0GOS / self.EGrayErr2GO[sel]).astype(dExpGraydC0ColorSplit.dtype))
 
             for i in range(c0s.size):
                 dExpGraydC0ColorSplit[ok, i, k] /= expGrayColorSplitWt[ok, k]
 
             np.add.at(dExpGraydC1ColorSplit[:, k],
                       self.obsExpIndexGO[sel],
-                      dDeltadC0GOS * self.deltaTGO[sel] / self.EGrayErr2GO[sel])
+                      (dDeltadC0GOS * self.deltaTGO[sel] / self.EGrayErr2GO[sel]).astype(dExpGraydC1ColorSplit.dtype))
 
             dExpGraydC1ColorSplit[ok, k] /= expGrayColorSplitWt[ok, k]
 
@@ -267,7 +267,7 @@ class FgcmMirrorChromaticity(object):
                   (2.0 * (expGrayColorSplitWt[ok, 0] + expGrayColorSplitWt[ok, 1]) *
                    (expGrayColorSplit[ok, 0] - expGrayColorSplit[ok, 1]) *
                    (dExpGraydC0ColorSplit[ok, self.fgcmPars.expCoatingIndex[ok], 0] -
-                    dExpGraydC0ColorSplit[ok, self.fgcmPars.expCoatingIndex[ok], 1])))
+                    dExpGraydC0ColorSplit[ok, self.fgcmPars.expCoatingIndex[ok], 1])).astype(deriv.dtype))
 
         deriv /= (ok.size - len(fitPars))
 

--- a/fgcm/fgcmChromaticity.py
+++ b/fgcm/fgcmChromaticity.py
@@ -5,6 +5,7 @@ import esutil
 import time
 import matplotlib.pyplot as plt
 import scipy.optimize as optimize
+from .fgcmUtilities import histogram_rev_sorted
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
@@ -354,7 +355,7 @@ class FgcmCCDChromaticity:
         ccdFilterHash = (obsLUTFilterIndexGO.astype(np.int64)*(self.fgcmPars.nCCD + 1) +
                          obsCCDIndexGO.astype(np.int64))
 
-        h, rev = esutil.stat.histogram(ccdFilterHash, rev=True)
+        h, rev = histogram_rev_sorted(ccdFilterHash)
 
         # Make a simple cut here.
         use, = np.where(h >= 10)

--- a/fgcm/fgcmConnectivity.py
+++ b/fgcm/fgcmConnectivity.py
@@ -4,6 +4,7 @@ import esutil
 import matplotlib.pyplot as plt
 
 from .fgcmUtilities import objFlagDict
+from .fgcmUtilities import histogram_rev_sorted
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
 class FgcmConnectivity(object):
@@ -76,8 +77,11 @@ class FgcmConnectivity(object):
                                 ((objFlag[obsObjIDIndex] & mask) == 0))
 
             # Split into nights with a histogram
-            h, rev = esutil.stat.histogram(self.fgcmPars.expNightIndex[obsExpIndex[goodObs]],
-                                           min=0, max=self.fgcmPars.nCampaignNights, rev=True)
+            h, rev = histogram_rev_sorted(
+                self.fgcmPars.expNightIndex[obsExpIndex[goodObs]],
+                min=0,
+                max=self.fgcmPars.nCampaignNights,
+            )
 
             done = False
             while not done:

--- a/fgcm/fgcmDeltaAper.py
+++ b/fgcm/fgcmDeltaAper.py
@@ -522,10 +522,10 @@ class FgcmDeltaAper(object):
 
         np.add.at(objDeltaAperMeanTemp,
                   (obsObjIDIndex[goodObs], obsBandIndex[goodObs]),
-                  (obsDeltaAper[goodObs] - self.fgcmPars.compMedDeltaAper[obsExpIndex[goodObs]])/obsMagErr2GO)
+                  ((obsDeltaAper[goodObs] - self.fgcmPars.compMedDeltaAper[obsExpIndex[goodObs]])/obsMagErr2GO).astype(objDeltaAperMeanTemp.dtype))
         np.add.at(wtSum,
                   (obsObjIDIndex[goodObs], obsBandIndex[goodObs]),
-                  1./obsMagErr2GO)
+                  (1./obsMagErr2GO).astype(wtSum.dtype))
 
         gd = np.where(wtSum > 0.0)
 

--- a/fgcm/fgcmDeltaAper.py
+++ b/fgcm/fgcmDeltaAper.py
@@ -8,6 +8,7 @@ import time
 import matplotlib.pyplot as plt
 
 from .fgcmUtilities import dataBinner
+from .fgcmUtilities import histogram_rev_sorted
 
 import multiprocessing
 
@@ -89,7 +90,7 @@ class FgcmDeltaAper(object):
         self.fgcmPars.compMedDeltaAper[:] = self.illegalValue
         self.fgcmPars.compEpsilon[:] = self.illegalValue
 
-        h, rev = esutil.stat.histogram(obsExpIndex[goodObs], rev=True, min=0)
+        h, rev = histogram_rev_sorted(obsExpIndex[goodObs], min=0)
         expIndices, = np.where(h >= self.minStarPerExp)
 
         for expIndex in expIndices:
@@ -248,7 +249,11 @@ class FgcmDeltaAper(object):
         # Do the mapping
         self.fgcmLog.info("Computing delta-aper epsilon spatial map at nside %d" % self.deltaAperFitSpatialNside)
         ipring = hpg.angle_to_pixel(self.deltaAperFitSpatialNside, objRA, objDec, nest=False)
-        h, rev = esutil.stat.histogram(ipring, min=0, max=hpg.nside_to_npixel(self.deltaAperFitSpatialNside) - 1, rev=True)
+        h, rev = histogram_rev_sorted(
+            ipring,
+            min=0,
+            max=hpg.nside_to_npixel(self.deltaAperFitSpatialNside) - 1,
+        )
 
         offsetMap = np.zeros(h.size, dtype=[('nstar_fit', 'i4', (self.fgcmStars.nBands, )),
                                             ('epsilon', 'f4', (self.fgcmStars.nBands, ))])
@@ -365,7 +370,7 @@ class FgcmDeltaAper(object):
 
         filterCcdHash = ccdIndexGO*(self.fgcmPars.nLUTFilter + 1) + lutFilterIndexGO
 
-        h, rev = esutil.stat.histogram(filterCcdHash, rev=True)
+        h, rev = histogram_rev_sorted(filterCcdHash)
 
         # Arbitrary minimum number here
         gdHash, = np.where(h > 10)
@@ -392,7 +397,7 @@ class FgcmDeltaAper(object):
 
             xyBinHash = xBin[i1a]*(self.deltaAperFitPerCcdNy + 1) + yBin[i1a]
 
-            h2, rev2 = esutil.stat.histogram(xyBinHash, rev=True)
+            h2, rev2 = histogram_rev_sorted(xyBinHash)
 
             gdHash2, = np.where(h2 > 10)
             for j in gdHash2:

--- a/fgcm/fgcmExposureSelector.py
+++ b/fgcm/fgcmExposureSelector.py
@@ -4,6 +4,7 @@ import sys
 import esutil
 
 from .fgcmUtilities import expFlagDict, logFlaggedExposuresPerBand, checkFlaggedExposuresPerBand
+from .fgcmUtilities import histogram_rev_sorted
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
@@ -143,8 +144,11 @@ class FgcmExposureSelector(object):
         self.fgcmLog.info('Flagging exposures on %d bad nights with too few photometric exposures.' % (badNights.size))
 
         # and we need to use *all* the exposures to flag bad nights
-        h,rev = esutil.stat.histogram(self.fgcmPars.expNightIndex,min=0,
-                                      max=self.fgcmPars.nCampaignNights-1,rev=True)
+        h, rev = histogram_rev_sorted(
+            self.fgcmPars.expNightIndex,
+            min=0,
+            max=self.fgcmPars.nCampaignNights - 1,
+        )
 
         for badNight in badNights:
             i1a=rev[rev[badNight]:rev[badNight+1]]

--- a/fgcm/fgcmGray.py
+++ b/fgcm/fgcmGray.py
@@ -211,10 +211,10 @@ class FgcmGray(object):
 
         np.add.at(expGrayForInitialSelection,
                   obsExpIndex[goodObs],
-                  EGray[goodObs])
+                  (EGray[goodObs]).astype(expGrayForInitialSelection.dtype))
         np.add.at(expGrayRMSForInitialSelection,
                   obsExpIndex[goodObs],
-                  EGray[goodObs]**2.)
+                  (EGray[goodObs]).astype(expGrayRMSForInitialSelection.dtype)**2.)
         np.add.at(expNGoodStarForInitialSelection,
                   obsExpIndex[goodObs],
                   1)
@@ -376,7 +376,7 @@ class FgcmGray(object):
 
         np.add.at(ccdGrayWt,
                   (obsExpIndex[goodObs],obsCCDIndex[goodObs]),
-                  1./EGrayErr2GO)
+                  (1./EGrayErr2GO).astype(ccdGrayWt.dtype))
         np.add.at(ccdNGoodStars,
                   (obsExpIndex[goodObs],obsCCDIndex[goodObs]),
                   1)
@@ -386,7 +386,7 @@ class FgcmGray(object):
                               obsBandIndex[goodObs]])
         np.add.at(ccdDeltaStd,
                   (obsExpIndex[goodObs], obsCCDIndex[goodObs]),
-                  obsDeltaStdGO/EGrayErr2GO)
+                  (obsDeltaStdGO/EGrayErr2GO).astype(ccdDeltaStd.dtype))
 
         gd = np.where((ccdNGoodStars >= 3) & (ccdGrayWt > 0.0))
         ccdDeltaStd[gd] /= ccdGrayWt[gd]
@@ -463,10 +463,10 @@ class FgcmGray(object):
 
                     np.add.at(ccdGrayTemp,
                               obsCCDIndex[goodObs[i1a]],
-                              EGrayGO[i1a]/EGrayErr2GO[i1a])
+                              (EGrayGO[i1a]/EGrayErr2GO[i1a]).astype(ccdGrayTemp.dtype))
                     np.add.at(ccdGrayRMSTemp,
                               obsCCDIndex[goodObs[i1a]],
-                              EGrayGO[i1a]**2./EGrayErr2GO[i1a])
+                              (EGrayGO[i1a]**2./EGrayErr2GO[i1a]).astype(ccdGrayRMSTemp.dtype))
 
                     gdTemp, = np.where((ccdNGoodStars[eInd, :] >= 3) &
                                        (ccdGrayWt[eInd, :] > 0.0) &
@@ -495,7 +495,7 @@ class FgcmGray(object):
                     ccdGrayEvalNStars = np.zeros(self.fgcmPars.nCCD, dtype=np.int32)
                     np.add.at(ccdGrayEval,
                               obsCCDIndex[goodObs[i1a]],
-                              ccdGrayEvalStars)
+                              ccdGrayEvalStars.astype(ccdGrayEval.dtype))
                     np.add.at(ccdGrayEvalNStars,
                               obsCCDIndex[goodObs[i1a]],
                               1)
@@ -536,10 +536,10 @@ class FgcmGray(object):
             # we can do all of this at once.
             np.add.at(ccdGray,
                       (obsExpIndex[goodObs],obsCCDIndex[goodObs]),
-                      EGrayGO/EGrayErr2GO)
+                      (EGrayGO/EGrayErr2GO).astype(ccdGray.dtype))
             np.add.at(ccdGrayRMS,
                       (obsExpIndex[goodObs],obsCCDIndex[goodObs]),
-                      EGrayGO**2./EGrayErr2GO)
+                      (EGrayGO**2./EGrayErr2GO).astype(ccdGrayRMS.dtype))
 
             # need at least 3 or else computation can blow up
             gd = np.where((ccdNGoodStars >= 3) & (ccdGrayWt > 0.0) & (ccdGrayRMS > 0.0))
@@ -679,25 +679,25 @@ class FgcmGray(object):
 
         np.add.at(expGrayWt,
                   goodCCD[0],
-                  1./ccdGrayErr[goodCCD]**2.)
+                  (1./ccdGrayErr[goodCCD]**2.).astype(ccdGrayWt.dtype))
         np.add.at(expGray,
                   goodCCD[0],
-                  ccdGray[goodCCD]/ccdGrayErr[goodCCD]**2.)
+                  (ccdGray[goodCCD]/ccdGrayErr[goodCCD]**2.).astype(expGray.dtype))
         np.add.at(expGrayRMS,
                   goodCCD[0],
-                  ccdGray[goodCCD]**2./ccdGrayErr[goodCCD]**2.)
+                  (ccdGray[goodCCD]**2./ccdGrayErr[goodCCD]**2.).astype(expGrayRMS.dtype))
         np.add.at(expNGoodCCDs,
                   goodCCD[0],
                   1)
         np.add.at(expNGoodTilings,
                   goodCCD[0],
-                  ccdNGoodTilings[goodCCD])
+                  (ccdNGoodTilings[goodCCD]).astype(expNGoodTilings.dtype))
         np.add.at(expNGoodStars,
                   goodCCD[0],
-                  ccdNGoodStars[goodCCD])
+                  (ccdNGoodStars[goodCCD]).astype(expNGoodStars.dtype))
         np.add.at(expDeltaStd,
                   goodCCD[0],
-                  ccdDeltaStd[goodCCD]/ccdGrayErr[goodCCD]**2.)
+                  (ccdDeltaStd[goodCCD]/ccdGrayErr[goodCCD]**2.).astype(expDeltaStd.dtype))
 
         if self.fgcmPars.nCCD >= 3:
             # Regular mode, when we have a multi-detector camera.
@@ -812,13 +812,13 @@ class FgcmGray(object):
 
             np.add.at(expGrayColorSplit[:, c],
                       obsExpIndex[goodObs[use]],
-                      EGrayGO[use] / EGrayErr2GO[use])
+                      (EGrayGO[use] / EGrayErr2GO[use]).astype(expGrayColorSplit.dtype))
             np.add.at(expGrayWtColorSplit[:, c],
                       obsExpIndex[goodObs[use]],
-                      1. / EGrayErr2GO[use])
+                      (1. / EGrayErr2GO[use]).astype(expGrayWtColorSplit.dtype))
             np.add.at(expGrayRMSColorSplit[:, c],
                       obsExpIndex[goodObs[use]],
-                      EGrayGO[use]**2. / EGrayErr2GO[use])
+                      (EGrayGO[use]**2. / EGrayErr2GO[use]).astype(expGrayRMSColorSplit.dtype))
             np.add.at(expGrayNGoodStarsColorSplit[:, c],
                       obsExpIndex[goodObs[use]],
                       1)

--- a/fgcm/fgcmGray.py
+++ b/fgcm/fgcmGray.py
@@ -12,6 +12,7 @@ from .fgcmUtilities import histoGauss
 from .fgcmUtilities import Cheb2dField
 from .fgcmUtilities import computeDeltaRA
 from .fgcmUtilities import expFlagDict
+from .fgcmUtilities import histogram_rev_sorted
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
@@ -403,7 +404,7 @@ class FgcmGray(object):
             FGrayGO = 10.**(EGrayGO/(-2.5))
             FGrayErrGO = (np.log(10.)/2.5)*np.sqrt(EGrayErr2GO)*FGrayGO
 
-            h, rev = esutil.stat.histogram(obsExpIndex[goodObs], rev=True)
+            h, rev = histogram_rev_sorted(obsExpIndex[goodObs])
 
             use, = np.where(h >= 3)
             for i in use:
@@ -574,7 +575,7 @@ class FgcmGray(object):
             expCcdHash = (obsExpIndex[goodObs]*(self.fgcmPars.nCCD + 1) +
                           obsCCDIndex[goodObs])
 
-            h, rev = esutil.stat.histogram(expCcdHash, rev=True)
+            h, rev = histogram_rev_sorted(expCcdHash)
 
             # Anything with 2 or fewer stars will be marked bad
             use, = np.where(h >= 3)
@@ -1206,7 +1207,7 @@ class FgcmGray(object):
         goodObs, = np.where(obsFlag == 0)
 
         # Do the exposures first
-        h, rev = esutil.stat.histogram(obsExpIndex[goodObs], rev=True)
+        h, rev = histogram_rev_sorted(obsExpIndex[goodObs])
 
         expDeltaMagBkg[:] = self.illegalValue
 
@@ -1228,7 +1229,7 @@ class FgcmGray(object):
         # Do the exp/ccd second
         expCcdHash = obsExpIndex[goodObs]*(self.fgcmPars.nCCD + 1) + obsCCDIndex[goodObs]
 
-        h, rev = esutil.stat.histogram(expCcdHash, rev=True)
+        h, rev = histogram_rev_sorted(expCcdHash)
 
         # We need at least 3 for a median, and of those from the percentile...
         use, = np.where(h > int(3./self.deltaMagBkgOffsetPercentile))
@@ -1289,7 +1290,7 @@ class FgcmGray(object):
             obsYGO = snmm.getArray(self.fgcmStars.obsYHandle)[goodObs]
             expCcdHash = (obsExpIndexGO[ok] * (self.fgcmPars.nCCD + 1) +
                           obsCCDIndexGO[ok])
-            h, rev = esutil.stat.histogram(expCcdHash, rev=True)
+            h, rev = histogram_rev_sorted(expCcdHash)
             use, = np.where(h > 0)
             for i in use:
                 i1a = rev[rev[i]: rev[i + 1]]
@@ -1318,7 +1319,7 @@ class FgcmGray(object):
 
         # And then this can be split per exposure.
 
-        h, rev = esutil.stat.histogram(obsExpIndexGO[goodRefObsGO], rev=True)
+        h, rev = histogram_rev_sorted(obsExpIndexGO[goodRefObsGO])
 
         use, = np.where(h >= self.minStarPerExp)
 

--- a/fgcm/fgcmMakeStars.py
+++ b/fgcm/fgcmMakeStars.py
@@ -6,6 +6,7 @@ import glob
 import hpgeom as hpg
 
 from .fgcmLogger import FgcmLogger
+from .fgcmUtilities import histogram_rev_sorted
 
 
 class FgcmMakeStars(object):
@@ -336,14 +337,14 @@ class FgcmMakeStars(object):
 
         # Split into pixels
         ipring = hpg.angle_to_pixel(self.starConfig['coarseNSide'], raArray, decArray, nest=False)
-        hpix, revpix = esutil.stat.histogram(ipring, rev=True)
+        hpix, revpix = histogram_rev_sorted(ipring)
 
         gdpix, = np.where(hpix > 0)
         self.fgcmLog.info("Matching primary stars in %d pixels" % (gdpix.size))
 
         for ii, gpix in enumerate(gdpix):
             # This is the array of all the observations in the coarse pixel
-            p1a=revpix[revpix[gpix]: revpix[gpix + 1]]
+            p1a = revpix[revpix[gpix]: revpix[gpix + 1]]
 
             if p1a.size == 0:
                 continue
@@ -445,7 +446,7 @@ class FgcmMakeStars(object):
 
                 # This is the official working version, but slower
                 fakeId = np.arange(p1a.size)
-                hist, rev = esutil.stat.histogram(fakeId[i1], rev=True)
+                hist, rev = histogram_rev_sorted(fakeId[i1])
 
                 if (hist.max() == 1):
                     self.fgcmLog.warning("  No matches found for pixel %d, %s band" %
@@ -681,7 +682,7 @@ class FgcmMakeStars(object):
             i1 = matches[1]
 
         self.fgcmLog.info("Collating observations")
-        nObsPerObj, obsInd = esutil.stat.histogram(i1, rev=True)
+        nObsPerObj, obsInd = histogram_rev_sorted(i1)
 
         if (nObsPerObj.size != self.objCat.size):
             raise ValueError("Number of primary stars (%d) does not match observations (%d)." %
@@ -729,13 +730,13 @@ class FgcmMakeStars(object):
             self.objCat['dec'][gd],
             nest=False
         )
-        hist, rev = esutil.stat.histogram(ipring, rev=True)
+        hist, rev = histogram_rev_sorted(ipring)
 
         high,=np.where(hist > self.starConfig['densMaxPerPixel'])
         ok,=np.where(hist > 0)
         self.fgcmLog.info("There are %d/%d pixels with high stellar density" % (high.size, ok.size))
         for i in range(high.size):
-            i1a=rev[rev[high[i]]:rev[high[i]+1]]
+            i1a = rev[rev[high[i]]: rev[high[i] + 1]]
             cut=np.random.choice(i1a,size=i1a.size-self.starConfig['densMaxPerPixel'],replace=False)
             objClass[gd[cut]] = 0
 
@@ -810,7 +811,7 @@ class FgcmMakeStars(object):
             self.objIndexCat['dec'],
             nest=False
         )
-        hpix, revpix = esutil.stat.histogram(ipring, rev=True)
+        hpix, revpix = histogram_rev_sorted(ipring)
 
         pixelCats = []
         nBands = len(self.starConfig['referenceFilterNames'])

--- a/fgcm/fgcmNumbaUtilities.py
+++ b/fgcm/fgcmNumbaUtilities.py
@@ -1,6 +1,6 @@
 try:
     from numba import jit
-    has_numba = True
+    has_numba = False
 except ImportError:
     has_numba = False
 

--- a/fgcm/fgcmParameters.py
+++ b/fgcm/fgcmParameters.py
@@ -1928,19 +1928,19 @@ class FgcmParameters(object):
                   1)
         np.add.at(mjdNight,
                   self.expNightIndex[expUse],
-                  self.expMJD[expUse])
+                  (self.expMJD[expUse]).astype(mjdNight.dtype))
         np.add.at(alphaNight,
                   self.expNightIndex[expUse],
-                  self.expAlpha[expUse])
+                  (self.expAlpha[expUse]).astype(alphaNight.dtype))
         np.add.at(tauNight,
                   self.expNightIndex[expUse],
-                  np.exp(self.expLnTau[expUse]))
+                  np.exp((self.expLnTau[expUse]).astype(tauNight.dtype)))
         np.add.at(pwvNight,
                   self.expNightIndex[expUse],
-                  np.exp(self.expLnPwv[expUse]))
+                  np.exp((self.expLnPwv[expUse]).astype(pwvNight.dtype)))
         np.add.at(O3Night,
                   self.expNightIndex[expUse],
-                  self.expO3[expUse])
+                  (self.expO3[expUse]).astype(O3Night.dtype))
 
         # hard code this for now
         gd,=np.where(nExpPerNight > self.minExpPerNight)

--- a/fgcm/fgcmQeSysSlope.py
+++ b/fgcm/fgcmQeSysSlope.py
@@ -7,6 +7,8 @@ import matplotlib.pyplot as plt
 import scipy.optimize
 from astropy.time import Time
 
+from .fgcmUtilities import histogram_rev_sorted
+
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
 class FgcmQeSysSlope(object):
@@ -80,7 +82,7 @@ class FgcmQeSysSlope(object):
         obsMagStdGO -= deltaQESlopeGO
 
         # split per wash interval
-        washH, washRev = esutil.stat.histogram(self.fgcmPars.expWashIndex[obsExpIndexGO], rev=True, min=0)
+        washH, washRev = histogram_rev_sorted(self.fgcmPars.expWashIndex[obsExpIndexGO], min=0)
         washIndices, = np.where(washH > 0)
 
         for washIndex in washIndices:
@@ -88,7 +90,7 @@ class FgcmQeSysSlope(object):
 
             # Split per band, and compute the delta-T and delta-Mag
 
-            bandH, bandRev = esutil.stat.histogram(obsBandIndex[goodObs[i1a]], rev=True, min=0)
+            bandH, bandRev = histogram_rev_sorted(obsBandIndex[goodObs[i1a]], min=0)
             bandIndices, = np.where(bandH > 0)
 
             deltaTAll = None

--- a/fgcm/fgcmRetrieveAtmosphere.py
+++ b/fgcm/fgcmRetrieveAtmosphere.py
@@ -10,6 +10,8 @@ import matplotlib.pyplot as plt
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
 from .fgcmUtilities import retrievalFlagDict
+from .fgcmUtilities import histogram_rev_sorted
+
 
 class FgcmRetrieveAtmosphere(object):
     """
@@ -121,7 +123,7 @@ class FgcmRetrieveAtmosphere(object):
 
         # next, we median together each exposure...
         minExpIndex = np.min(expIndexArray[zUse])
-        h, rev = esutil.stat.histogram(expIndexArray[zUse], min=minExpIndex, rev=True)
+        h, rev = histogram_rev_sorted(expIndexArray[zUse], min=minExpIndex)
 
         gd, = np.where(h >= self.minCCDPerExp)
 
@@ -142,8 +144,7 @@ class FgcmRetrieveAtmosphere(object):
         # next, we do the median smoothing using pwvRetrievalSmoothBlock
         # self.pwvRetrievalSmoothBlock = fgcmConfig.pwvRetrievalSmoothBlock
 
-        h, rev = esutil.stat.histogram(self.fgcmPars.expNightIndex[rLnPwvStruct['EXPINDEX']],
-                                       rev=True)
+        h, rev = histogram_rev_sorted(self.fgcmPars.expNightIndex[rLnPwvStruct['EXPINDEX']])
 
         # we do this on any night that we have at least 1
         gd, = np.where(h > 0)
@@ -177,7 +178,7 @@ class FgcmRetrieveAtmosphere(object):
         nightIndexWithLnPwv = np.unique(self.fgcmPars.expNightIndex[rLnPwvStruct['EXPINDEX']])
 
         a, b = esutil.numpy_util.match(nightIndexWithLnPwv, self.fgcmPars.expNightIndex)
-        h, rev = esutil.stat.histogram(self.fgcmPars.expNightIndex[b], rev=True)
+        h, rev = histogram_rev_sorted(self.fgcmPars.expNightIndex[b])
 
         gd, = np.where(h > 0)
 
@@ -385,8 +386,7 @@ class FgcmRetrieveAtmosphere(object):
             extDelta = (-2.5*np.log10(r0[expIndexArray[use], ccdIndexArray[use]]) +
                          2.5*np.log10(I0Ref))
 
-            h,rev = esutil.stat.histogram(self.fgcmPars.expNightIndex[expIndexArray[use]],
-                                          rev=True, min=0)
+            h, rev = histogram_rev_sorted(self.fgcmPars.expNightIndex[expIndexArray[use]], min=0)
 
             gd, = np.where(h > self.tauRetrievalMinCCDPerNight)
             if not self.quietMode:
@@ -534,8 +534,7 @@ class FgcmRetrieveAtmosphere(object):
             extDelta = (-2.5*np.log10(r0Gray[use]) +
                          2.5*np.log10(I0Ref))
 
-            h,rev = esutil.stat.histogram(self.fgcmPars.expNightIndex[expIndexArray[use]],
-                                          rev=True, min=0)
+            h, rev = histogram_rev_sorted(self.fgcmPars.expNightIndex[expIndexArray[use]], min=0)
 
             gd, = np.where(h > self.tauRetrievalMinCCDPerNight)
             if not self.quietMode:

--- a/fgcm/fgcmSigmaCal.py
+++ b/fgcm/fgcmSigmaCal.py
@@ -5,6 +5,7 @@ import esutil
 import time
 
 from .fgcmUtilities import retrievalFlagDict
+from .fgcmUtilities import histogram_rev_sorted
 
 import multiprocessing
 
@@ -209,8 +210,11 @@ class FgcmSigmaCal(object):
                         continue
 
                     # These have already been limited to the plot percentile range
-                    h, rev = esutil.stat.histogram(objMagStdMean[goodStars[plotIndices[band][ok]], bandIndex],
-                                                   nbin=nPlotBin, rev=True)
+                    h, rev = histogram_rev_sorted(
+                        objMagStdMean[goodStars[plotIndices[band][ok]], bandIndex],
+                        nbin=nPlotBin,
+                    )
+
                     for j, nInBin in enumerate(h):
                         if nInBin < 100:
                             continue

--- a/fgcm/fgcmSigmaCal.py
+++ b/fgcm/fgcmSigmaCal.py
@@ -368,8 +368,8 @@ class FgcmSigmaCal(object):
 
         np.add.at(objChi2,
                   (obsObjIDIndexGO, obsBandIndexGO),
-                  ((obsMagStdGO - objMagStdMean[obsObjIDIndexGO, obsBandIndexGO])**2. /
-                   obsMagErr2GO))
+                  (((obsMagStdGO - objMagStdMean[obsObjIDIndexGO, obsBandIndexGO])**2. /
+                   obsMagErr2GO)).astype(objChi2.dtype))
         # There are duplicate indices here, but that's fine because we only want to divide once
         objChi2[obsObjIDIndexGO, obsBandIndexGO] /= (objNGoodObs[obsObjIDIndexGO, obsBandIndexGO] - 1.0)
 

--- a/fgcm/fgcmStars.py
+++ b/fgcm/fgcmStars.py
@@ -1427,8 +1427,16 @@ class FgcmStars(object):
         wt = 1. / (objMagStdMeanErr[goodRefStars, :]**2. +
                    refMagErr[objRefIDIndex[goodRefStars], :]**2.)
 
-        np.add.at(deltaOffsetRef, gdBandInd, delta[gdStarInd, gdBandInd] * wt[gdStarInd, gdBandInd])
-        np.add.at(deltaOffsetWtRef, gdBandInd, wt[gdStarInd, gdBandInd])
+        np.add.at(
+            deltaOffsetRef,
+            gdBandInd,
+            (delta[gdStarInd, gdBandInd] * wt[gdStarInd, gdBandInd]).astype(deltaOffsetRef.dtype),
+        )
+        np.add.at(
+            deltaOffsetWtRef,
+            gdBandInd,
+            (wt[gdStarInd, gdBandInd]).astype(deltaOffsetWtRef.dtype),
+        )
 
         # Make sure we have a measurement in the band
         ok, = np.where(deltaOffsetWtRef > 0.0)

--- a/fgcm/fgcmStars.py
+++ b/fgcm/fgcmStars.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from .fgcmUtilities import objFlagDict
 from .fgcmUtilities import obsFlagDict
 from .fgcmUtilities import getMemoryString
+from .fgcmUtilities import histogram_rev_sorted
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
@@ -1639,7 +1640,7 @@ class FgcmStars(object):
                            (fgcmPars.nCCD+1) +
                            obsCCDIndex[goodObs])
 
-        h, rev = esutil.stat.histogram(epochFilterHash, rev=True)
+        h, rev = histogram_rev_sorted(epochFilterHash)
 
         nbad = 0
 
@@ -1711,7 +1712,7 @@ class FgcmStars(object):
         # compute EGray, GO for Good Obs
         EGrayGO, EGrayErr2GO = self.computeEGray(goodObs, onlyObsErr=True, ignoreRef=ignoreRef)
 
-        h, rev = esutil.stat.histogram(obsExpIndex[goodObs], rev=True)
+        h, rev = histogram_rev_sorted(obsExpIndex[goodObs])
 
         nbad = 0
 
@@ -1770,7 +1771,7 @@ class FgcmStars(object):
                                (fgcmPars.nCCD+1) +
                                obsCCDIndex)
 
-            h, rev = esutil.stat.histogram(epochFilterHash, rev=True)
+            h, rev = histogram_rev_sorted(epochFilterHash)
 
             for i in range(h.size):
                 if h[i] == 0: continue

--- a/fgcm/fgcmSuperStarFlat.py
+++ b/fgcm/fgcmSuperStarFlat.py
@@ -157,12 +157,12 @@ class FgcmSuperStarFlat(object):
                       (self.fgcmPars.expEpochIndex[obsExpIndex[goodObs2]],
                        self.fgcmPars.expLUTFilterIndex[obsExpIndex[goodObs2]],
                        obsCCDIndex[goodObs2]),
-                      1./EGrayErr2GO[mark])
+                      (1./EGrayErr2GO[mark]).astype(superStarWt.dtype))
             np.add.at(superStarOffset,
                       (self.fgcmPars.expEpochIndex[obsExpIndex[goodObs2]],
                        self.fgcmPars.expLUTFilterIndex[obsExpIndex[goodObs2]],
                        obsCCDIndex[goodObs2]),
-                      EGrayGO[mark]/EGrayErr2GO[mark])
+                      (EGrayGO[mark]/EGrayErr2GO[mark]).astype(superStarOffset.dtype))
             np.add.at(superStarNGoodStars,
                       (self.fgcmPars.expEpochIndex[obsExpIndex[goodObs2]],
                        self.fgcmPars.expLUTFilterIndex[obsExpIndex[goodObs2]],

--- a/fgcm/fgcmSuperStarFlat.py
+++ b/fgcm/fgcmSuperStarFlat.py
@@ -13,6 +13,8 @@ import matplotlib.cm as cmx
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 from .fgcmUtilities import Cheb2dField
+from .fgcmUtilities import histogram_rev_sorted
+
 
 class FgcmSuperStarFlat(object):
     """
@@ -200,7 +202,7 @@ class FgcmSuperStarFlat(object):
                                (self.fgcmPars.nCCD+1) +
                                obsCCDIndex[goodObs])
 
-            h, rev = esutil.stat.histogram(epochFilterHash, rev=True)
+            h, rev = histogram_rev_sorted(epochFilterHash)
 
             for i in range(h.size):
                 if h[i] == 0: continue

--- a/fgcm/fgcmUtilities.py
+++ b/fgcm/fgcmUtilities.py
@@ -154,7 +154,12 @@ def dataBinner(x,y,binSize,xRange,nTrial=100,xNorm=-1.0,minPerBin=5):
 
     import esutil
 
-    hist,rev=esutil.stat.histogram(x,binsize=binSize,min=xRange[0],max=xRange[1]-0.0001,rev=True)
+    hist, rev = histogram_rev_sorted(
+        x,
+        binsize=binSize,
+        min=xRange[0],
+        max=xRange[1] - 0.0001,
+    )
     binStruct=np.zeros(hist.size,dtype=[('X_BIN','f4'),
                                         ('X','f4'),
                                         ('X_ERR_MEAN','f4'),
@@ -913,7 +918,7 @@ class FocalPlaneProjectorFromOffsets(object):
         else:
             sub = np.arange(obsX.size)
 
-        h, rev = esutil.stat.histogram(obsCCDIndex[sub], rev=True)
+        h, rev = histogram_rev_sorted(obsCCDIndex[sub])
 
         for i in range(h.size):
             if h[i] == 0: continue
@@ -924,7 +929,7 @@ class FocalPlaneProjectorFromOffsets(object):
 
             if self.ccdOffsets['RASIGN'][cInd] == 0:
                 # choose a good exposure to work with
-                hTest, revTest = esutil.stat.histogram(obsExpIndex[i1a], rev=True)
+                hTest, revTest = histogram_rev_sorted(obsExpIndex[i1a])
                 # Exclude the first index which will be invalid exposures.
                 maxInd = np.argmax(hTest[1: ]) + 1
                 testStars = revTest[revTest[maxInd]: revTest[maxInd + 1]]

--- a/fgcm/fgcmUtilities.py
+++ b/fgcm/fgcmUtilities.py
@@ -86,6 +86,37 @@ def getMemoryString(location):
 
     return memoryString
 
+
+def histogram_rev_sorted(data, binsize=1.0, nbin=None, min=None, max=None):
+    """Vendored edit of esutil.stat.histogram with proper sorting.
+
+    Parameters
+    ----------
+    arr : `np.ndarray`
+    binsize : `float`, optional
+    nbin : `int`, optional
+    min : `float`, optional
+    max : `float`, optional
+
+    Returns
+    -------
+    h : `np.ndarray`
+        Histogram values
+    rev : `np.ndarray`
+        Reverse indices (sorted)
+    """
+    import esutil
+
+    if nbin is not None:
+        binsize = None
+
+    b = esutil.stat.Binner(data)
+    b.sort_index = data.argsort(kind="stable")
+    b.dohist(binsize=binsize, nbin=nbin, min=min, max=max, rev=True, calc_stats=False)
+
+    return b["hist"], b["rev"]
+
+
 def dataBinner(x,y,binSize,xRange,nTrial=100,xNorm=-1.0,minPerBin=5):
     """
     Bin data and compute errors via bootstrap resampling.  All median statistics.

--- a/fgcm/fgcmZeropoints.py
+++ b/fgcm/fgcmZeropoints.py
@@ -9,6 +9,7 @@ from .fgcmUtilities import zpFlagDict
 from .fgcmUtilities import expFlagDict
 from .fgcmUtilities import Cheb2dField
 from .fgcmUtilities import dataBinner
+from .fgcmUtilities import histogram_rev_sorted
 
 from .sharedNumpyMemManager import SharedNumpyMemManager as snmm
 
@@ -301,7 +302,7 @@ class FgcmZeropoints(object):
         # need secZenith for each exp/ccd pair
         deltaRA = np.zeros(zpStruct.size)
         deltaDec = np.zeros(zpStruct.size)
-        h, rev = esutil.stat.histogram(zpExpIndex, rev=True)
+        h, rev = histogram_rev_sorted(zpExpIndex)
         ok, = np.where(h > 0)
         for i in ok:
             i1a = rev[rev[i]: rev[i + 1]]
@@ -722,7 +723,7 @@ class FgcmZeropoints(object):
                            (self.fgcmPars.nCCD + 1) +
                            zpCCDIndex)
 
-        h, rev = esutil.stat.histogram(epochFilterHash, rev=True)
+        h, rev = histogram_rev_sorted(epochFilterHash)
 
         for i in range(h.size):
             if h[i] == 0: continue

--- a/fgcm/fgcmZeropoints.py
+++ b/fgcm/fgcmZeropoints.py
@@ -607,7 +607,7 @@ class FgcmZeropoints(object):
 
             np.add.at(expZpMean,
                       zpExpIndex[okCCD],
-                      zpStruct['FGCM_ZPT'][okCCD])
+                      (zpStruct['FGCM_ZPT'][okCCD]).astype(expZpMean.dtype))
             np.add.at(expZpNCCD,
                       zpExpIndex[okCCD],
                       1)
@@ -978,8 +978,8 @@ class FgcmZeropointPlotter(object):
             meanR1 = np.zeros(nCCD)
             nPerCCD = np.zeros(nCCD,dtype=np.int32)
 
-            np.add.at(meanI1, ccdIndex, i1)
-            np.add.at(meanR1, ccdIndex, r1)
+            np.add.at(meanI1, ccdIndex, i1.astype(meanI1.dtype))
+            np.add.at(meanR1, ccdIndex, r1.astype(meanR1.dtype))
             np.add.at(nPerCCD, ccdIndex, 1)
 
             use,=np.where(nPerCCD > 0)


### PR DESCRIPTION
This fixes deprecation warnings and more importantly makes sure that the histogram indices are sorted for reliable repeatability on different systems/versions/sort algorithms.