### PR TITLE
Add config to pre-cut high fwhm exposures.

### DIFF
--- a/fgcm/fgcmConfig.py
+++ b/fgcm/fgcmConfig.py
@@ -163,6 +163,7 @@ class FgcmConfig(object):
     expGrayInitialCut = ConfigField(float, default=-0.25)
     expVarGrayPhotometricCutDict = ConfigField(dict, default={})
     expGrayPhotometricCutDict = ConfigField(dict, required=True)
+    expFwhmCutDict = ConfigField(dict, required=True)
     expGrayRecoverCut = ConfigField(float, default=-1.0)
     expGrayHighCutDict = ConfigField(dict, required=True)
     expGrayErrRecoverCut = ConfigField(float, default=0.05)
@@ -469,6 +470,10 @@ class FgcmConfig(object):
                                                                  float, -0.05,
                                                                  ndarray=True, required=True,
                                                                  dictName='expGrayPhotometricCutDict')
+        self.expFwhmCut = self._convertDictToBandList(self.expFwhmCutDict,
+                                                      float, 100.0,
+                                                      ndarray=True, required=False,
+                                                      dictName='expFwhmCutDict')
         self.expGrayHighCut = self._convertDictToBandList(self.expGrayHighCutDict,
                                                           float, 0.10,
                                                           ndarray=True, required=True,

--- a/fgcm/fgcmDeltaAper.py
+++ b/fgcm/fgcmDeltaAper.py
@@ -68,12 +68,15 @@ class FgcmDeltaAper(object):
         self.njyZp = 8.9 + 9*2.5
         self.k = 2.5/np.log(10.)
 
-    def computeDeltaAperExposures(self):
+    def computeDeltaAperExposures(self, doFullFit=False):
         """
         Compute deltaAper per-exposure quantities
         """
         if not self.quietMode:
-            self.fgcmLog.info('Computing deltaAper per exposure')
+            if doFullFit:
+                self.fgcmLog.info('Computing deltaAper per exposure')
+            else:
+                self.fgcmLog.info('Computing deltaAper offset per exposure')
 
         objMagStdMean = snmm.getArray(self.fgcmStars.objMagStdMeanHandle)
         objNGoodObs = snmm.getArray(self.fgcmStars.objNGoodObsHandle)
@@ -115,6 +118,9 @@ class FgcmDeltaAper(object):
             cutMag = mag[ok[st[int(0.25*st.size)]]]
             bright, = np.where(mag[ok] < cutMag)
             self.fgcmPars.compMedDeltaAper[expIndex] = np.median(deltaAper[ok[bright]])
+
+            if not doFullFit:
+                continue
 
             fit, _ = self._fitEpsilonWithDataBinner(mag[ok], deltaAper[ok])
 

--- a/fgcm/fgcmDeltaAper.py
+++ b/fgcm/fgcmDeltaAper.py
@@ -243,7 +243,7 @@ class FgcmDeltaAper(object):
                 yplotvals = fit[0]*((2.5/np.log(10.0))/xplotfluxvals) + fit[1]
                 ax.plot(xplotvals, yplotvals, 'r-')
                 ax.set_xlabel('mag_std_%s' % (band))
-                ax.set_ylabel('delta_aper_%s' % (band))
+                ax.set_ylabel('Normalized delta_aper_%s' % (band))
                 ax.set_title('%s: %.4f nJy/arcsec2' % (band, globalEpsilon[i]))
 
                 if self.butlerQC is not None:

--- a/fgcm/fgcmExposureSelector.py
+++ b/fgcm/fgcmExposureSelector.py
@@ -21,6 +21,7 @@ class FgcmExposureSelector(object):
         # and config variables...
         self.minStarPerExp = fgcmConfig.minStarPerExp
         self.minExpPerNight = fgcmConfig.minExpPerNight
+        self.expFwhmCut = fgcmConfig.expFwhmCut
         self.expGrayPhotometricCut = fgcmConfig.expGrayPhotometricCut
         self.expVarGrayPhotometricCut = fgcmConfig.expVarGrayPhotometricCut
         self.expGrayHighCut = fgcmConfig.expGrayHighCut
@@ -35,6 +36,12 @@ class FgcmExposureSelector(object):
         # based on those in the parameter file if they're available
 
         self.fgcmPars.expFlag[:] = 0
+
+        bad, = np.where(self.fgcmPars.expFwhm > self.expFwhmCut[self.fgcmPars.expBandIndex])
+        self.fgcmPars.expFlag[bad] |= expFlagDict['BAD_FWHM']
+        self.fgcmLog.info('Flagged %d bad exposures with bad fwhm.' % (bad.size))
+        if not self.quietMode:
+            logFlaggedExposuresPerBand(self.fgcmLog, self.fgcmPars, 'BAD_FWHM')
 
         bad,=np.where(self.fgcmPars.compNGoodStarPerExp == 0)
         self.fgcmPars.expFlag[bad] |= expFlagDict['NO_STARS']
@@ -99,6 +106,12 @@ class FgcmExposureSelector(object):
 
         # reset all exposure flags
         self.fgcmPars.expFlag[:] = 0
+
+        bad, = np.where(self.fgcmPars.expFwhm > self.expFwhmCut[self.fgcmPars.expBandIndex])
+        self.fgcmPars.expFlag[bad] |= expFlagDict['BAD_FWHM']
+        self.fgcmLog.info('Flagged %d bad exposures with bad fwhm.' % (bad.size))
+        if not self.quietMode:
+            logFlaggedExposuresPerBand(self.fgcmLog, self.fgcmPars, 'BAD_FWHM')
 
         bad,=np.where(expNGoodStarForInitialSelection < self.minStarPerExp)
         self.fgcmPars.expFlag[bad] |= expFlagDict['TOO_FEW_STARS']

--- a/fgcm/fgcmFitCycle.py
+++ b/fgcm/fgcmFitCycle.py
@@ -519,8 +519,9 @@ class FgcmFitCycle(object):
             self.fgcmDeltaAper = FgcmDeltaAper(self.fgcmConfig, self.fgcmPars,
                                                self.fgcmStars,
                                                butlerQC=self.butlerQC, plotHandleDict=self.plotHandleDict)
-            if self.fgcmConfig.doComputeDeltaAperExposures:
-                self.fgcmDeltaAper.computeDeltaAperExposures()
+            self.fgcmDeltaAper.computeDeltaAperExposures(
+                doFullFit=self.fgcmConfig.doComputeDeltaAperExposures,
+            )
             if self.fgcmConfig.doComputeDeltaAperStars:
                 self.fgcmDeltaAper.computeDeltaAperStars()
                 # Only run if we have the values per star.

--- a/fgcm/fgcmUtilities.py
+++ b/fgcm/fgcmUtilities.py
@@ -31,7 +31,8 @@ expFlagDict = {'TOO_FEW_STARS':2**0,
                'BAND_NOT_IN_LUT':2**5,
                'TEMPORARY_BAD_EXPOSURE':2**6,
                'EXP_GRAY_TOO_POSITIVE':2**7,
-               'BAD_ZPFLAG':2**8}
+               'BAD_ZPFLAG':2**8,
+               'BAD_FWHM':2**9}
 
 # Dictionary of zeropoint flags
 zpFlagDict = {'PHOTOMETRIC_FIT_EXPOSURE':2**0,

--- a/fgcm/fgcmZeropoints.py
+++ b/fgcm/fgcmZeropoints.py
@@ -447,7 +447,8 @@ class FgcmZeropoints(object):
         acceptMask = (expFlagDict['EXP_GRAY_TOO_NEGATIVE'] |
                       expFlagDict['EXP_GRAY_TOO_POSITIVE'] |
                       expFlagDict['VAR_GRAY_TOO_LARGE'] |
-                      expFlagDict['TOO_FEW_STARS'])
+                      expFlagDict['TOO_FEW_STARS'] |
+                      expFlagDict['BAD_FWHM'])
 
         nonPhotZpIndex, = np.where(((self.fgcmPars.expFlag[zpExpIndex] & acceptMask) > 0) &
                            ((self.fgcmPars.expFlag[zpExpIndex] & rejectMask) == 0))


### PR DESCRIPTION
This also fixes a bug in that the global epsilon plots were incorrect if visit-level epsilon measurements were not made.